### PR TITLE
First pass at winding in the worldine formulation

### DIFF
--- a/supervillain/observable/topology.py
+++ b/supervillain/observable/topology.py
@@ -42,6 +42,8 @@ class WindingSquared(Observable):
         .. math::
 
             w_p =  \frac{1}{\pi^2 \kappa}-\frac{1}{(2\pi \kappa)^2}\left\langle (dm)_p^2 \right\rangle.
+
+        because $\delta / \delta J_p ( d \delta J_p) = 4$.
         '''
         return 1/(np.pi**2 * S.kappa)-np.mean(S.Lattice.d(1, m)**2) / (2*np.pi*S.kappa)**2
 
@@ -76,10 +78,9 @@ class Winding_Winding(Observable):
     def Worldline(S, m):
         r'''
         .. collapse :: The Worldline observable is trickier.
-            :open:
             :class: note:
 
-            Expanding the :class:`~.Worldline` action (and dropping the irrelevant contants)
+            Expanding the :class:`~.Worldline` action (and grouping the irrelevant contants)
 
             .. math::
                 \begin{align}
@@ -100,25 +101,27 @@ class Winding_Winding(Observable):
                 \frac{\delta}{\delta J_p} \log Z
                     &= \frac{1}{Z} \sum Dm\; [\delta m = 0] e^{-S_J[m]} \frac{\delta S}{\delta J_p}
                     \\
-                    &= \frac{1}{Z} \sum Dm\; [\delta m = 0] e^{-S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_p + \frac{1}{4\pi^2} (d\delta J)_p \right)
+                    &= \frac{1}{Z} \sum Dm\; [\delta m = 0] e^{-S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_p + \frac{2}{4\pi^2} (d\delta J)_p \right)
                 \end{align}
+
+            where the factor of 2 on the $d \delta J$ term comes from the fact that $J d \delta J$ is quadratic in $J$.
 
             Differentiating again we must hit both the $1/Z$ term and the path integral upstairs giving two terms,
 
             .. math::
                 \begin{align}
                 \frac{\delta}{\delta J_q}\frac{\delta}{\delta J_p} \log Z
-                    =& \frac{\delta}{\delta J_q} \left[\frac{1}{Z} \sum Dm\; [\delta m = 0] e^{S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_p + \frac{1}{4\pi^2} (d\delta J)_p \right) \right]
+                    =& \frac{\delta}{\delta J_q} \left[\frac{1}{Z} \sum Dm\; [\delta m = 0] e^{S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_p + \frac{1}{2\pi^2} (d\delta J)_p \right) \right]
                     \\
-                    =& -\frac{1}{Z^2} \left[\sum Dm\; [\delta m = 0] e^{S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_p + \frac{1}{4\pi^2} (d\delta J)_p \right) \right]
+                    =& -\frac{1}{Z^2} \left[\sum Dm\; [\delta m = 0] e^{S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_p + \frac{1}{2\pi^2} (d\delta J)_p \right) \right]
                     \\
-                    & \phantom{-\frac{1}{Z^2}}\times \left[\sum Dm\; [\delta m = 0] e^{S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_q + \frac{1}{4\pi^2} (d\delta J)_q \right) \right]
+                    & \phantom{-\frac{1}{Z^2}}\times \left[\sum Dm\; [\delta m = 0] e^{S_J[m]} \frac{-1}{2\kappa}\left( -\frac{1}{\pi} (dm)_q + \frac{1}{2\pi^2} (d\delta J)_q \right) \right]
                     \\
                     &+ \frac{1}{Z} \sum Dm\; [\delta m = 0] e^{S_J[m]} \Bigg[
                     \\
-                    & \phantom{-\frac{1}{Z^2}} \left(\frac{-1}{2\kappa}\right)^2\left( -\frac{1}{\pi} (dm)_q + \frac{1}{4\pi^2} (d\delta J)_q \right)\left( -\frac{1}{\pi} (dm)_p + \frac{1}{4\pi^2} (d\delta J)_p \right)
+                    & \phantom{-\frac{1}{Z^2}} \left(\frac{-1}{2\kappa}\right)^2\left( -\frac{1}{\pi} (dm)_q + \frac{1}{2\pi^2} (d\delta J)_q \right)\left( -\frac{1}{\pi} (dm)_p + \frac{1}{2\pi^2} (d\delta J)_p \right)
                     \\
-                    & \phantom{-\frac{1}{Z^2}} +\frac{-1}{8\pi^2 \kappa}\frac{\delta}{\delta J_q} (d \delta J)_p 
+                    & \phantom{-\frac{1}{Z^2}} +\frac{-1}{4\pi^2 \kappa}\frac{\delta}{\delta J_q} (d \delta J)_p 
                     \Bigg]
                 \\
                 \end{align}
@@ -134,33 +137,41 @@ class Winding_Winding(Observable):
                 \\
                 &- \left\langle (dm)_p (dm)_q \right\rangle
                 \\
-                & + \frac{\kappa}{2} \frac{\delta}{\delta J_q} (d \delta J)_p \Bigg\}
+                & + \kappa \left.\frac{\delta}{\delta J_q} (d \delta J)_p\right|_{J=0} \Bigg\}
                 \end{align}
 
             because $d\delta 0 = 0$.
 
-            When $J=0$ the first (quantum-disconnected) term is proportional $\left\langle dm_p \right\rangle \left\langle dm_q \right\rangle$ and the individual expectation values vanish by symmetry so we are left with.
+            When $J=0$ the first (quantum-disconnected) term is proportional $\left\langle dm_p \right\rangle \left\langle dm_q \right\rangle$ and the individual expectation values vanish by symmetry so we are left with
 
             .. math ::
                 \begin{align}
                 -\left.\frac{\delta}{\delta J_q}\frac{\delta}{\delta J_p} \log Z \right|_{J=0}
                 = \left(\frac{1}{2\pi \kappa}\right)^2\Bigg\{&
-                \frac{\kappa}{2} \frac{\delta}{\delta J_q} (d \delta J)_p 
+                \kappa \left.\frac{\delta}{\delta J_q} (d \delta J)_p  \right|_{J=0}
                 - \left\langle (dm)_p (dm)_q \right\rangle\Bigg\}
                 \end{align}
 
-            Careful evaluation shows that $d \delta J =0$ when $J=0$ and that we ought to treat $d \delta J$ as independent from $J$, so that the functional derivative in the final term vanishes.
+            The remaining functional derivative is a displacement-dependent constant.
 
 
         At the end of the day all we are left with is
 
         .. math::
-            - \frac{\delta}{\delta J_p} \frac{\delta}{\delta J_q}\log Z = \frac{1}{(2\pi \kappa)^2}\left\{\frac{\kappa}{2}\frac{\delta}{\delta J_q}(d \delta J) - \left\langle (dm)_p (dm_q) \right\rangle\right\}
+            - \frac{\delta}{\delta J_p} \frac{\delta}{\delta J_q}\log Z = \frac{1}{(2\pi \kappa)^2}\left\{\kappa\left.\frac{\delta}{\delta J_q}(d \delta J_p)\right|_{J=0} - \left\langle (dm)_p (dm_q) \right\rangle\right\}
 
-        which simplifies if the functional derivative vanishes.
+        when $J=0$.  In 2D $\left.\frac{\delta}{\delta J_q}(d \delta J_p)\right|_{J=0} = 4 \delta_{pq} - \sum_{\hat{\mu}} \delta_{p+\hat{\mu},q}$ where $\hat{\mu}$ runs over the 4 cardinal directions, reproducing (minus) the standard `2D five-point Laplacian stencil <https://en.wikipedia.org/wiki/Five-point_stencil#In_two_dimensions>`_.
         '''
         L = S.Lattice
         kappa = S.kappa
         dm = L.d(1, m)
-        return - L.correlation(dn, dn) / (2*np.pi*kappa)**2
+
+        # δ/δJ_p (d δ (J_q)) doesn't vanish, but neither does it depends on J.
+        # In fact, it is a constant that depends only the relative coordinate.
+        # We can get the stencil by computing δ d (all zeros except at the origin)
+        no_displacement = L.form(2)
+        no_displacement[0,0] = 1.
+        d_delta_J = L.d(1, L.delta(2, no_displacement))
+
+        return (kappa * d_delta_J - L.correlation(dm, dm)) / (2*np.pi*kappa)**2
 


### PR DESCRIPTION
This is a PR that should ultimately implement the Winding_Winding and WindingSquared observables.

HOWEVER, it should not yet be merged.  There is a big issue though:

If δ/δJ (dδJ) = 0 then the worldline WindingSquared is negative semidefinite and the Villain is positive semidefinite.  If there is no mistake this would prove that WindingSquared = 0, which
 - is false from running Villain samples.
 - would imply that very plaquette's winding = 0, also false.
