### PR TITLE
TorusWrapping is probably slow

### DIFF
--- a/supervillain/observable.rst
+++ b/supervillain/observable.rst
@@ -82,6 +82,14 @@ Winding
    :members:
    :show-inheritance:
 
+--------
+Wrapping
+--------
+
+.. autoclass :: supervillain.observable.TorusWrapping
+   :members:
+   :show-inheritance:
+
 -----------------
 Spin Correlations
 -----------------

--- a/supervillain/observable/__init__.py
+++ b/supervillain/observable/__init__.py
@@ -4,4 +4,5 @@ from .derived import DerivedQuantity
 from .energy import InternalEnergyDensity, InternalEnergyDensitySquared
 from .action import ActionDensity, ActionTwoPoint, Action_Action
 from .topology import WindingSquared, Winding_Winding
+from .wrapping import TorusWrapping
 from .spin import Spin_Spin, SpinSusceptibility, SpinSusceptibilityScaled

--- a/supervillain/observable/wrapping.py
+++ b/supervillain/observable/wrapping.py
@@ -1,0 +1,39 @@
+from supervillain.observable import Observable
+import numpy as np
+
+class TorusWrapping(Observable):
+    r'''
+    Both the :class:`~.Villain` and :class:`~.Worldline` formulations have integer-valued numbers that wrap the spatial torus.
+
+    .. warning ::
+        Unlike most observables these will NOT match${}^*$ between the different formulations.
+        However, since they are both related to the global topology, we expect them to evolve quite slowly and suffer the longest autocorrelation times.
+
+        ${}^*$They both have 0 expectation value by the discrete rotational lattice symmetries, but they don't have related physical motivation.
+    '''
+
+
+    @staticmethod
+    def Villain(S, phi, n):
+        r'''
+        The total wrapping in direction $\mu$ is given by the gauge holonomy
+
+        .. math ::
+            \texttt{TorusWrapping}_{\mu} = \sum n_\mu
+        '''
+
+        L = S.Lattice
+        return n.sum(axis=(-2,-1))
+
+    @staticmethod
+    def Worldline(S, m):
+        r'''
+        The total wrapping in direction $\mu$ is given by the net particle flux in that direction
+
+        .. math ::
+            \texttt{TorusWrapping}_{\mu} = \frac{1}{|\mu|} \sum m_\mu
+
+        where we divide by the length of the dimension because a torus-wrapping $m$ will get contributions from every μ-slice.
+        '''
+
+        return m.sum(axis=(-2,-1)) / S.Lattice.dims


### PR DESCRIPTION
I'd like to usually avoid observables where the different implementations have different physical meaning.  However this one has the same spiritual meaning instead: it's probably the slowest mode for any substantial lattice.

Here's 10^6 samples for a 5x5 lattice with κ=0.5, measured every 1000.  Upper panel is Villain, lower is Worldline.  Blue is wrapping in time, orange is wrapping in space.

![Screenshot 2023-09-29 at 12 30 28](https://github.com/evanberkowitz/supervillain/assets/129339/4286ff6b-afba-423c-bdb7-98c23ca455a5)


You can see in the histograms that the values come out to be integer and that the different directions have the same distribution.  With κ=0.5 on this small lattice the autocorrelation times (we have to select single components)

```
print(supervillain.analysis.autocorrelation_time(ensemble.TorusWrapping[:,0]))
print(supervillain.analysis.autocorrelation_time(ensemble.TorusWrapping[:,1]))
```

are actually not so bad for the Villain model (about 80 steps in comparison to the ~300 for InternalEnergyDensity, InternalEnergyDensitySquared, WindingSquared).  For the Worldline formulation it's about 2 (compared to 4 for the other observables).  Of course the autocorrelation is algorithm dependent and this is a very small lattice so it shouldn't be taken too seriously.