### PR TITLE
Fix the symmetrization

### DIFF
--- a/supervillain/lattice.py
+++ b/supervillain/lattice.py
@@ -941,7 +941,7 @@ class Lattice2D(H5able):
         permutation = []
         for i in range(self.sites):
             for j in range(self.sites):
-                if (self.coordinates[i] == np.matmul(operator, self.coordinates[j])).all():
+                if (self.coordinates[i] == self.mod(np.matmul(operator, self.coordinates[j]))).all():
                     permutation += [j]
                     continue # since a permutation is one-to-one
         return np.array(permutation)


### PR DESCRIPTION
The symmetrization was lifted from tdg where, for reasons of ergodicity, we only do N=odd.  But here we do N=even too.  There was a bug for N=even.

The bug was that the set of coordinates for an even-sized lattice is not closed under a naive application of the symmetry group operations.

However, if we mod the coordinates back into the lattice all is fixed.