### PR TITLE
NotImplemented --> NotImplementedError

### DIFF
--- a/supervillain/cli/log.py
+++ b/supervillain/cli/log.py
@@ -45,7 +45,7 @@ class StarStarSugar:
     # we make sure that we can **unpack StarStarSugar objects into parser.add_argument.
     def method(self, values):
         # Each child class needs to provide their own method.
-        raise NotImplemented()
+        raise NotImplementedError()
 
 def LogAction(action):
     '''Construct an argparse.Action on the fly with init and call determined by the passed action.'''

--- a/supervillain/observable/observable.py
+++ b/supervillain/observable/observable.py
@@ -63,10 +63,10 @@ class Observable:
                     for obs in zip(*[getattr(obj, o) for o in inspect.getfullargspec(measure).args])
                     ])
             return obj.__dict__[name]
-        except:
-            raise NotImplemented(f'{name} not implemented for {class_name}')
+        except Exception as exception:
+            raise NotImplementedError(f'{name} not implemented for {class_name}') from exception
 
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __set__(self, obj, value):
         setattr(obj, self.name, value)


### PR DESCRIPTION
These are not the same!

NotImplemented is a sentinel singleton designed to be returned in unimplemented comparators to indicate the opposite comparison should be tried.  Importantly it is not callable!  It doesn't raise an exception!

NotImplementedError is the exception.