### PR TITLE
No notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.png
 *.log
 .DS_Store
+.ipynb
 
 # Docs
 _build/


### PR DESCRIPTION
Because jupyter notebooks are very hard to version-track + control, we should really only include them after certain steps have been met.  For example, all the output should be deleted (so that there aren't any figures being committed).

Really, notebooks are useful for your own development; production code should be in the library or in scripts.