### PR TITLE
Fix erroneous derivation + corresponding code

### DIFF
--- a/supervillain/observable/energy.py
+++ b/supervillain/observable/energy.py
@@ -90,14 +90,14 @@ class InternalEnergyDensitySquared(Scalar, Observable):
             \begin{align}
                 \partial_\kappa S &= - \frac{1}{2\kappa^2} \sum_{\ell} (m-\delta v/W)_\ell^2 + \frac{|\ell|}{2 \kappa}
                 &
-                \partial^2_\kappa S &= \frac{1}{\kappa} \sum_{\ell} (m-\delta v/W)_\ell^2 - \frac{|\ell|}{2\kappa^2}.
+                \partial^2_\kappa S &= \frac{1}{\kappa^3} \sum_{\ell} (m-\delta v/W)_\ell^2 - \frac{|\ell|}{2\kappa^2}.
             \end{align}
 
         '''
 
         L = S.Lattice
         partial_kappa_S = (L.links / 2 - 0.5 / S.kappa * (Links**2).sum()) / S.kappa
-        partial_2_kappa_S = ((Links**2).sum() - L.links / S.kappa) / S.kappa
+        partial_2_kappa_S = ((Links**2).sum() / S.kappa - L.links / 2) / S.kappa**2
         
         return (partial_kappa_S**2 - partial_2_kappa_S) / L.sites**2
 


### PR DESCRIPTION
#98 described a bug in InternalEnergyDensitySquared.

This provides the fix.  One thing that @alcherman noticed was that the discrepancy seemed volume-dependent.  To speed things up we did simulations with a 2x2 lattice, κ=0.5, W=1.  Both Villain (100000 NeighborhoodUpdates) and Worldline (10000 sequential Plaquette and WrappingUpdates).  Computed the autocorrelation times, decorrelated, and did 1000 bootstrap resamplings.  That should be enough to guarantee gaussian statistics.

Before the fix we see an obvious incontrovertible difference in the InternalEnergyDensitySquared observable.

![Screenshot 2024-01-24 at 19 36 17](https://github.com/evanberkowitz/supervillain/assets/129339/8c493b24-e931-49bb-ac88-16f11a3aa20d)

With this fix they now agree (and indeed, it is the Worldline that changed, not the Villain!)

![Screenshot 2024-01-24 at 19 34 04](https://github.com/evanberkowitz/supervillain/assets/129339/184f8497-13e9-4d24-a8f5-e55c3b2c8a82)

Now running the 5x5 lattice used as an example in #98, we get something definitely compatible:

![Screenshot 2024-01-24 at 19 45 15](https://github.com/evanberkowitz/supervillain/assets/129339/f169d9a3-949a-4d5c-a349-539a2779b572)

This closes #98.