### PR TITLE
changes.rst contains recent git log

### DIFF
--- a/changes.rst
+++ b/changes.rst
@@ -1,0 +1,9 @@
+Recent Changes
+==============
+
+.. git_commit_detail::
+   :branch:
+   :commit:
+
+.. git_changelog::
+   :detailed-message-pre: True

--- a/index.rst
+++ b/index.rst
@@ -27,11 +27,12 @@ supervillain
 Version Information
 ===================
 
+.. toctree::
+   changes
+
 .. git_commit_detail::
    :branch:
    :commit:
-   :uncommitted:
-   :untracked:
 
 License
 =======


### PR DESCRIPTION
Also remove the untracked / uncommitted changes; that seems to appear on RtD even though the repo there should be clean.  I assume it's because the compilation produces some h5 files, but why aren't they ignored?