### PR TITLE
Feature/numba worm

### DIFF
--- a/example/action-comparison.py
+++ b/example/action-comparison.py
@@ -12,9 +12,9 @@ import supervillain.analysis.comparison_plot as comparison_plot
 supervillain.observable.progress=tqdm
 
 parser = supervillain.cli.ArgumentParser(description = 'The goal is to compute the same observables using both the Villain and Worldline actions and to check that they agree.  The Villain action is sampled with a combination of Site and Link Updates and the worm.')
-parser.add_argument('--N', type=int, default=5, help='Sites on a side.')
+parser.add_argument('--N', type=int, default=5, help='Sites on a side.  Defaults to 5.')
 parser.add_argument('--kappa', type=float, default=0.5, help='κ.  Defaults to 0.5.')
-parser.add_argument('--W', default=supervillain.cli.W, help='Constraint integer W.  Defaults to 1')
+parser.add_argument('--W', type=supervillain.cli.W, default=1, help='Constraint integer W.  Defaults to 1')
 parser.add_argument('--configurations', type=int, default=100000, help='Defaults to 100000.  You need a good deal of configurations with κ=0.5 because of autocorrelations in the Villain sampling.')
 parser.add_argument('--figure', default=False, type=str)
 parser.add_argument('--observables', nargs='*', help='Names of observables to compare.  Defaults to a list of 5 observables.',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 numpy>=1.21
 scipy>=1.8
+numba>=0.60
 
 # IO
 

--- a/supervillain/generator.rst
+++ b/supervillain/generator.rst
@@ -247,7 +247,7 @@ Just like the Villain case we can measure a two-point correlator inline, but in 
 
 which amounts to constructing a normalized histogram after ensemble averaging.
 
-.. autoclass :: supervillain.generator.worldline.worm.Classic
+.. autoclass :: supervillain.generator.worldline.worm.ClassicWorm
    :members:
 
 Finally, we provide a convenience function which provides an ergodic generator.

--- a/supervillain/generator.rst
+++ b/supervillain/generator.rst
@@ -268,3 +268,14 @@ Another (trivial) combination is a decorrelating application.
 
 .. autoclass :: supervillain.generator.combining.KeepEvery
    :members:
+
+--------
+Monitors
+--------
+
+We can make pass-through generators to perform specific tasks, like logging.
+
+.. autoclass :: supervillain.generator.monitor.Logger
+   :members:
+
+One could construct monitors that, for example, measured observables inline.

--- a/supervillain/generator/__init__.py
+++ b/supervillain/generator/__init__.py
@@ -6,3 +6,4 @@ from .example import DoNothing
 import supervillain.generator.villain
 import supervillain.generator.worldline
 import supervillain.generator.combining
+import supervillain.generator.monitor

--- a/supervillain/generator/monitor.py
+++ b/supervillain/generator/monitor.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import numpy as np
+from supervillain.generator import Generator
+from supervillain.h5 import ReadWriteable
+
+from supervillain.performance import Timer
+
+class Logger(ReadWriteable, Generator):
+    r'''
+
+    Mostly good for debugging.
+
+    .. code-block :: python
+
+       import logging
+       logger = logging.getLogger(__name__)
+
+       ...
+
+       L = supervillain.lattice.Lattice2D(N)
+       S = supervillain.action.Worldline(L, kappa, W)
+       G = supervillain.generator.worldline.Hammer(S, L.sites)
+       M = supervillain.generator.monitor.Logger(G, logger.info)
+       E = supervillain.Ensemble(S).generate(100, M)
+
+    Parameters
+    ----------
+    generator: any generator
+        The generator to wrap.
+    channel: some function
+        Will be applied to the resulting configuration.
+    '''
+
+    def __init__(self, generator, channel):
+        
+        self.generator = generator
+        self.channel = channel
+        self.iterations = 0
+        
+    def __str__(self):
+        return f'Monitor((' + ', '.join(f'{str(g)}' for g in self.generators) + '))'
+
+    def step(self, cfg):
+        r'''
+        Apply the wrapped generator and channel the result.
+        '''
+        
+        with Timer(self.channel, f'Iteration {self.iterations}'):
+            result = cfg
+            result |= self.generator.step(result)
+            
+            self.channel(result)
+        self.iterations += 1
+
+        return result
+
+    def inline_observables(self, steps):
+        r'''
+        Forwards to the wrapped generator.
+        '''
+        return self.generator.inline_observables(steps)
+
+    def report(self):
+        r'''
+        Forwards to the wrapped generator.
+        '''
+        return self.generator.report()

--- a/supervillain/generator/reference_implementation/worldline.py
+++ b/supervillain/generator/reference_implementation/worldline.py
@@ -7,9 +7,6 @@ from supervillain.generator import Generator
 from supervillain.h5 import ReadWriteable
 import supervillain.h5.extendable as extendable
 
-from supervillain.lattice import _Lattice2D
-import numba
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -28,14 +25,6 @@ class ClassicWorm(ReadWriteable, Generator):
         
         When $W>1$ this update algorithm is not ergodic on its own.  It doesn't change $v$ at all.
         However, when $W=1$ we can always pick $v=0$ (any other choice may be absorbed into $m$), and this generator can stand alone.
-
-    .. note ::
-
-       This class contains kernels accelerated using numba.
-
-    .. seealso::
-
-       There is :class:`a reference implementation without any numba acceleration <supervillain.generator.reference_implementation.worldline.ClassicWorm>`.
 
     '''
 
@@ -57,6 +46,19 @@ class ClassicWorm(ReadWriteable, Generator):
 
     def __str__(self):
         return 'ClassicWorm'
+
+    def _neighboring_sites(self, here):
+        # east, north, west, south
+        return self.Action.Lattice.mod(here + np.array([[+1,0], [0,+1], [-1,0], [0,-1]]))
+
+    def _adjacent_links(self, here):
+        # These are the directions we'd like to move the head of the defect.
+        east, north, west, south = self._neighboring_sites(here)
+
+        return ((0, here [0], here [1]), # t link to the east
+                (1, here [0], here [1]), # x link to the north
+                (0, west [0], west [1]), # t link to the west
+                (1, south[0], south[1])) # x link to the south
 
     def inline_observables(self, steps):
         r'''
@@ -102,51 +104,29 @@ class ClassicWorm(ReadWriteable, Generator):
         # by placing the head and tail down we have moved to the g sector!
         # Now we are ready to start evolving in z union g.
 
-        new_m, spin_spin = worm_kernel(
-            _Lattice2D(self.Action.Lattice.dims),
-            S.kappa,
-            head, tail,
-            m, delta_v_by_W, change_m
-        )
-
-        wl = spin_spin.sum()
-        self.worm_lengths.append(wl)
-        return {'m': new_m, 'v': v, 'Spin_Spin': spin_spin, 'Worm_Length': wl}
-
-
-    def report(self):
-        l = np.array(self.worm_lengths)
-        return f'There were {len(l)} worms.\nWorms lengths:\n    mean {l.mean()}\n    std  {l.std()}\n    max  {max(l)}'
-
-@numba.jit
-def worm_kernel(_Lattice, kappa, head, tail, m, delta_v_by_W, change_m):
-
-    displacements = np.zeros((_Lattice.nt, _Lattice.nx), dtype=np.int64)
-
-    L = _Lattice
-
-    while True:
+        while True:
             # In the general case we will uniformly choose between 4 moves,
             # but if the head and tail are together, we add the g--> z transition.
             # This has likelihood of 20%, conditioned on the worm being closed.
             # If it is proposed, however, the change in action is 0 and it is automatically accepted as a z configuration.
-            if (head == tail).all() and (np.random.uniform(0., 1.) >= 0.8):
-                return m, displacements
+            if (head == tail).all() and (self.rng.uniform(0, 1) >= 0.8):
+                wl = displacements.sum()
+                self.worm_lengths.append(wl)
+                return {'m': m, 'v': v, 'Spin_Spin': displacements, 'Worm_Length': wl}
 
             # Conditioned on not transitioning to z, we make a uniform choice of the 4 possible directions.
-            choice = np.random.choice(np.arange(4))
+            choice = self.rng.choice([0,1,2,3])
 
             # Now we propose a move to the next position.
-            t, x = L.neighboring_sites(head)
-            nxt = np.array([t[choice], x[choice]], dtype=np.int64)
+            next = self._neighboring_sites(head)[choice]
             # in which case we will cross the corresponding link.
-            link = L.adjacent_links(0, head)[choice]
+            link = self._adjacent_links(head)[choice]
 
             # Crossing the link changes m and therefore the action.
             change_link = m[link] - delta_v_by_W[link]
             delta_m = change_m[choice]
             change_S = (
-                (1 / (2*kappa)) *
+                (1 / (2*S.kappa)) *
                 delta_m *
                 (2*change_link + delta_m)
             )
@@ -155,12 +135,12 @@ def worm_kernel(_Lattice, kappa, head, tail, m, delta_v_by_W, change_m):
             #
             #   A = min(1, exp(-ΔS) )
             #
-            A = np.min(np.array([1., np.exp(-change_S)])) # numba doesn't support clip?
+            A = np.clip(np.exp(-change_S), a_min=0, a_max=1)
 
             # and Metropolis-test the update.
-            if np.random.uniform(0., 1.) < A:
+            if self.rng.uniform(0, 1) < A:
                 # If it accepted we move the head
-                head = nxt
+                head = next
                 # and cross the link.
                 m[link] += delta_m
 
@@ -168,5 +148,9 @@ def worm_kernel(_Lattice, kappa, head, tail, m, delta_v_by_W, change_m):
             x, y = L.mod(head-tail)
             displacements[x, y] +=1
             # and consider our next move.
+
+    def report(self):
+        l = np.array(self.worm_lengths)
+        return f'There were {len(l)} worms.\nWorms lengths:\n    mean {l.mean()}\n    std  {l.std()}\n    max  {max(l)}'
 
 

--- a/supervillain/generator/worldline/__init__.py
+++ b/supervillain/generator/worldline/__init__.py
@@ -3,7 +3,7 @@ from .wrapping import WrappingUpdate
 from .plaquette import PlaquetteUpdate
 from .vortex import VortexUpdate
 from .coexact import CoexactUpdate
-from .worm import Classic as Worm
+from .worm import ClassicWorm as Worm
 
 import supervillain.generator.combining as _combining
 

--- a/supervillain/lattice.py
+++ b/supervillain/lattice.py
@@ -1124,3 +1124,113 @@ class Lattice2D(ReadWriteable):
             temp += w * np.take(C, p, -1)
 
         return self.coordinatize(temp, dims=dims)
+
+
+import numba
+from numba.experimental import jitclass
+
+@jitclass([
+    ('nt', numba.int64),
+    ('nx', numba.int64),
+    ('dims', numba.int64[:]),
+    ('t',  numba.int64[:]),
+    ('x',  numba.int64[:]),
+    ])
+class _Lattice2D:
+    r'''
+    A numba-accelerated collection of lattice functions.
+
+    .. warning::
+       
+       NOT ALL LATTICES METHODS ARE INCLUDED; THEY MAY BE ADDED OVER TIME AS NEEDED.
+
+       Moreover, not all methods have the same signature due to limitations in numba.
+
+    .. note ::
+        
+        Currently `numba jitclasses do not support classmethods <https://numba.readthedocs.io/en/stable/proposals/jit-classes.html>`_.
+        In particular, that makes they incompatible with
+        our HDF5 infrastructure; they cannot be made :class:`~.ReadWriteable`, for instance.
+
+        Therefore, they should be set as class members; you may need to reconstruct them.
+    '''
+
+    def __init__(self, dims):
+        self.nt = dims[0]
+        self.nx = dims[1]
+
+        self.dims = np.array(dims)
+
+        self.t = self._dimension(self.nt)
+        self.x = self._dimension(self.nx)
+
+    def _dimension(self, n):
+        return np.concatenate((
+            np.arange(0, n // 2 + 1, dtype=np.int64),
+            np.arange( - n // 2 + 1, 0, dtype=np.int64),
+            ))
+
+    def mod(self, points=np.array([[]])):
+        r'''
+
+        .. warning ::
+           The return value is unpacked along each dimension.
+           This seemed to be a peculiar requirement of numba.
+        
+        Parameters
+        ----------
+        points: 2D np.array
+            An n×2 array of points to be modded.
+
+        Returns
+        -------
+        t: np.array
+            The first coordinate of each point modded into the lattice.
+        x: np.array
+            The second coordinate of each point modded into the lattice.
+        '''
+        flip = points.T
+        t_modded = np.mod(flip[0], self.nt)
+        x_modded = np.mod(flip[1], self.nx)
+        return self.t[t_modded], self.x[x_modded]
+
+    def neighboring_sites(self, here):
+        # east, north, west, south
+        return self.mod(here + np.array([[+1,0], [0,+1], [-1,0], [0,-1]]))
+
+    def neighboring_plaquettes(self, here):
+        # east, north, west, south
+        return self.mod(here + np.array([[+1,0], [0,+1], [-1,0], [0,-1]]))
+
+    def adjacent_links(self, form, site):
+        # Links to the east, north, west, and south
+        t, x = self.neighboring_sites(site)
+        east = np.array([t[0], x[0]])
+        north= np.array([t[1], x[1]])
+        west = np.array([t[2], x[2]])
+        south= np.array([t[3], x[3]])
+
+
+        if form == 0:
+            #     n
+            #     |
+            #   w-h-e
+            #     |
+            #     s
+
+            return ((0, site [0], site [1]), # t link to the east
+                    (1, site [0], site [1]), # x link to the north
+                    (0, west [0], west [1]), # t link to the west
+                    (1, south[0], south[1])) # x link to the south
+
+        if form == 2:
+            #        n
+            #       +-+
+            #      w|h|e
+            #       o-+
+            #        s
+
+            return ((1, east [0], east [1]), # t link to the east
+                    (0, north[0], north[1]), # x link to the north
+                    (1, site [0], site [1]), # t link to the west
+                    (0, site [0], site [1])) # x link to the south

--- a/supervillain/lattice.py
+++ b/supervillain/lattice.py
@@ -1146,6 +1146,8 @@ class _Lattice2D:
 
        Moreover, not all methods have the same signature due to limitations in numba.
 
+       Seriously this is to be used but rarely.  Used only in :class:`~.worldline.ClassicWorm`.
+
     .. note ::
         
         Currently `numba jitclasses do not support classmethods <https://numba.readthedocs.io/en/stable/proposals/jit-classes.html>`_.

--- a/supervillain/lattice.rst
+++ b/supervillain/lattice.rst
@@ -9,3 +9,6 @@ Currently we focus on the 1+1 model.
 
 .. autoclass :: supervillain.lattice.Lattice2D
    :members:
+
+.. autoclass :: supervillain.lattice._Lattice2D
+   :members:

--- a/supervillain/lattice.rst
+++ b/supervillain/lattice.rst
@@ -10,5 +10,3 @@ Currently we focus on the 1+1 model.
 .. autoclass :: supervillain.lattice.Lattice2D
    :members:
 
-.. autoclass :: supervillain.lattice._Lattice2D
-   :members:

--- a/supervillain/reference_implementations.rst
+++ b/supervillain/reference_implementations.rst
@@ -22,6 +22,11 @@ Villain NeighborhoodUpdate
 .. autoclass :: supervillain.generator.reference_implementation.villain.NeighborhoodUpdateSlow
    :members:
 
+Wordline Classic Worm
+=====================
+.. autoclass :: supervillain.generator.reference_implementation.worldline.ClassicWorm
+   :members:
+
 
 
 ===========


### PR DESCRIPTION
Giovanni Pederiva (@GioPede) suggest I look at numba to accelerate the worm, given that the kernel is now completely understood, relatively tight, and the slowest part of sampling.

I'm happy to say that on the little parallel production demo it cuts the whole pipeline from 4 minutes to 2.5 minutes.

Also
 - For W=3 N=7 κ=0.08 (below critical) the speed-up was ~3.5 times measured on 1000 configurations
 - Same but N=21 it was closer to 5 times.

Running `example/action-comparison.py` shows that the hammers still match.