### PR TITLE
Add absolute topological-charge density observable

### DIFF
--- a/supervillain/form.rst
+++ b/supervillain/form.rst
@@ -164,6 +164,7 @@ which is checked by the ``test_wedge_associative`` test in :source:`test/test_la
 The Leibniz rule
 
 .. math::
+   :label: leibniz-rule
 
    d(a \wedge b) = da \wedge b + (-1)^{\deg a}\, a \wedge db
 

--- a/supervillain/generator/villain/__init__.py
+++ b/supervillain/generator/villain/__init__.py
@@ -20,9 +20,9 @@ def Hammer(S, worms=1):
 
     .. note ::
 
-        The :class:`~.ClassicWorm` is currently only implemented for $D=2$.  In higher
-        dimensions the Hammer omits it, so the returned combination is not ergodic on its
-        own until a $D>2$ worm is available.
+        The :class:`~supervillain.generator.villain.worm.ClassicWorm` is currently only
+        implemented for $D=2$.  In higher dimensions the Hammer omits it, so the returned
+        combination is not ergodic on its own until a $D>2$ worm is available.
 
     Parameters
     ----------

--- a/supervillain/observable.rst
+++ b/supervillain/observable.rst
@@ -55,33 +55,53 @@ Action
 Topological Charge
 ==================
 
-The absolute topological-charge density can be measured alongside the action
-density on any generated four-dimensional, :math:`W=1` Villain ensemble:
+In four dimensions we can define a simple 4-form topological charge observable $Q_x$ in the Villain frame,
 
-.. code-block:: python
+.. math ::
 
-   import supervillain
+   \begin{aligned}
+      Q &= \sum_x Q_x
+      &
+      Q_x = (dn \wedge dn)_x.
+   \end{aligned}
 
-   L = supervillain.lattice.Lattice(D=4, N=4)
-   S = supervillain.action.Villain(L, kappa=0.05, W=1)
-   G = supervillain.generator.villain.NeighborhoodUpdate(S)
+In D=4 the density is a top-form.
+The charge density is exact, since
 
-   ensemble = supervillain.Ensemble(S).generate(
-       1_000,
-       G,
-       start='cold',
-   )
-   measurements = ensemble.measure([
-       'ActionDensity',
-       'AbsoluteTopologicalChargeDensity',
-   ])
-   absolute_charge_density = measurements['AbsoluteTopologicalChargeDensity']
+.. math ::
 
-``absolute_charge_density`` contains one scalar value per generated
-configuration.  Accessing ``ensemble.AbsoluteTopologicalChargeDensity`` gives
-the same cached measurement.
+   \begin{aligned}
+      Q_x &= dn \wedge dn = d(n \wedge dn) = (dJ)_x
+      &
+      J &= n \wedge dn
+   \end{aligned}
+
+and the Leibniz rule :eq:`leibniz-rule` holds exactly.
+This means that the charge is locally conserved, and the total charge vanishes configuration by configuration.
+(Of course you could equally well say that $J \sim dn \wedge n$.)
+
 
 .. autoclass :: supervillain.observable.AbsoluteTopologicalChargeDensity
+   :members:
+   :show-inheritance:
+
+.. autoclass :: supervillain.observable.TopologicalChargeDensity
+   :members:
+   :show-inheritance:
+
+.. autoclass :: supervillain.observable.TopologicalCharge
+   :members:
+   :show-inheritance:
+
+.. autoclass :: supervillain.observable.TopologicalChargeSquared
+   :members:
+   :show-inheritance:
+
+.. autoclass :: supervillain.observable.TopologicalTwoPoint
+   :members:
+   :show-inheritance:
+
+.. autoclass :: supervillain.observable.Topological_Topological
    :members:
    :show-inheritance:
 

--- a/supervillain/observable.rst
+++ b/supervillain/observable.rst
@@ -55,14 +55,14 @@ Action
 Topological Charge
 ==================
 
-In four dimensions we can define a simple 4-form topological charge observable $Q_x$ in the Villain frame,
+In four dimensions we can define a simple 4-form topological-charge density $q_x$ in the Villain frame,
 
 .. math ::
 
    \begin{aligned}
-      Q &= \sum_x Q_x
+      Q &= \sum_x q_x
       &
-      Q_x = (dn \wedge dn)_x.
+      q_x = (dn \wedge dn)_x.
    \end{aligned}
 
 In D=4 the density is a top-form.
@@ -71,13 +71,13 @@ The charge density is exact, since
 .. math ::
 
    \begin{aligned}
-      Q_x &= dn \wedge dn = d(n \wedge dn) = (dJ)_x
+      q_x &= dn \wedge dn = d(n \wedge dn) = (dJ)_x
       &
       J &= n \wedge dn
    \end{aligned}
 
 and the Leibniz rule :eq:`leibniz-rule` holds exactly.
-This means that the charge is locally conserved, and the total charge vanishes configuration by configuration.
+This means that the charge is locally conserved, and the total charge $Q$ vanishes configuration by configuration.
 (Of course you could equally well say that $J \sim dn \wedge n$.)
 
 

--- a/supervillain/observable.rst
+++ b/supervillain/observable.rst
@@ -89,7 +89,7 @@ This means that the charge is locally conserved, and the total charge vanishes c
    :members:
    :show-inheritance:
 
-.. autoclass :: supervillain.observable.TopologicalChargeSquared
+.. autoclass :: supervillain.observable.TopologicalChargeDensitySquared
    :members:
    :show-inheritance:
 

--- a/supervillain/observable.rst
+++ b/supervillain/observable.rst
@@ -81,10 +81,6 @@ This means that the charge is locally conserved, and the total charge vanishes c
 (Of course you could equally well say that $J \sim dn \wedge n$.)
 
 
-.. autoclass :: supervillain.observable.AbsoluteTopologicalChargeDensity
-   :members:
-   :show-inheritance:
-
 .. autoclass :: supervillain.observable.TopologicalChargeDensity
    :members:
    :show-inheritance:

--- a/supervillain/observable.rst
+++ b/supervillain/observable.rst
@@ -51,6 +51,40 @@ Action
    :members:
    :show-inheritance:
 
+==================
+Topological Charge
+==================
+
+The absolute topological-charge density can be measured alongside the action
+density on any generated four-dimensional, :math:`W=1` Villain ensemble:
+
+.. code-block:: python
+
+   import supervillain
+
+   L = supervillain.lattice.Lattice(D=4, N=4)
+   S = supervillain.action.Villain(L, kappa=0.05, W=1)
+   G = supervillain.generator.villain.NeighborhoodUpdate(S)
+
+   ensemble = supervillain.Ensemble(S).generate(
+       1_000,
+       G,
+       start='cold',
+   )
+   measurements = ensemble.measure([
+       'ActionDensity',
+       'AbsoluteTopologicalChargeDensity',
+   ])
+   absolute_charge_density = measurements['AbsoluteTopologicalChargeDensity']
+
+``absolute_charge_density`` contains one scalar value per generated
+configuration.  Accessing ``ensemble.AbsoluteTopologicalChargeDensity`` gives
+the same cached measurement.
+
+.. autoclass :: supervillain.observable.AbsoluteTopologicalChargeDensity
+   :members:
+   :show-inheritance:
+
 =======
 Winding
 =======

--- a/supervillain/observable/__init__.py
+++ b/supervillain/observable/__init__.py
@@ -5,6 +5,7 @@ from .derived import DerivedQuantity
 from .links import Links
 from .energy import InternalEnergyDensity, InternalEnergyDensitySquared, InternalEnergyDensityVariance, SpecificHeatCapacity
 from .action import ActionDensity, ActionTwoPoint, Action_Action
+from .topological import AbsoluteTopologicalChargeDensity
 from .winding import WindingSquared, Winding_Winding
 from .wrapping import TorusWrapping, WrappingSquared
 from .spin import Spin_Spin, Spin_Spin_Normalized, SpinSusceptibility, SpinSusceptibilityScaled, SpinCriticalMoment

--- a/supervillain/observable/__init__.py
+++ b/supervillain/observable/__init__.py
@@ -5,7 +5,7 @@ from .derived import DerivedQuantity
 from .links import Links
 from .energy import InternalEnergyDensity, InternalEnergyDensitySquared, InternalEnergyDensityVariance, SpecificHeatCapacity
 from .action import ActionDensity, ActionTwoPoint, Action_Action
-from .topological import AbsoluteTopologicalChargeDensity, TopologicalChargeDensity, TopologicalCharge, TopologicalChargeSquared, TopologicalTwoPoint, Topological_Topological
+from .topological import TopologicalChargeDensity, TopologicalCharge, TopologicalChargeSquared, TopologicalTwoPoint, Topological_Topological
 from .winding import WindingSquared, Winding_Winding
 from .wrapping import TorusWrapping, WrappingSquared
 from .spin import Spin_Spin, Spin_Spin_Normalized, SpinSusceptibility, SpinSusceptibilityScaled, SpinCriticalMoment

--- a/supervillain/observable/__init__.py
+++ b/supervillain/observable/__init__.py
@@ -5,7 +5,7 @@ from .derived import DerivedQuantity
 from .links import Links
 from .energy import InternalEnergyDensity, InternalEnergyDensitySquared, InternalEnergyDensityVariance, SpecificHeatCapacity
 from .action import ActionDensity, ActionTwoPoint, Action_Action
-from .topological import TopologicalChargeDensity, TopologicalCharge, TopologicalChargeSquared, TopologicalTwoPoint, Topological_Topological
+from .topological import TopologicalChargeDensity, TopologicalCharge, TopologicalChargeDensitySquared, TopologicalTwoPoint, Topological_Topological
 from .winding import WindingSquared, Winding_Winding
 from .wrapping import TorusWrapping, WrappingSquared
 from .spin import Spin_Spin, Spin_Spin_Normalized, SpinSusceptibility, SpinSusceptibilityScaled, SpinCriticalMoment

--- a/supervillain/observable/__init__.py
+++ b/supervillain/observable/__init__.py
@@ -5,7 +5,7 @@ from .derived import DerivedQuantity
 from .links import Links
 from .energy import InternalEnergyDensity, InternalEnergyDensitySquared, InternalEnergyDensityVariance, SpecificHeatCapacity
 from .action import ActionDensity, ActionTwoPoint, Action_Action
-from .topological import AbsoluteTopologicalChargeDensity
+from .topological import AbsoluteTopologicalChargeDensity, TopologicalChargeDensity, TopologicalCharge, TopologicalChargeSquared, TopologicalTwoPoint, Topological_Topological
 from .winding import WindingSquared, Winding_Winding
 from .wrapping import TorusWrapping, WrappingSquared
 from .spin import Spin_Spin, Spin_Spin_Normalized, SpinSusceptibility, SpinSusceptibilityScaled, SpinCriticalMoment

--- a/supervillain/observable/topological.py
+++ b/supervillain/observable/topological.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import numpy as np
+
+import supervillain.action
+from supervillain.lattice import d, wedge
+from supervillain.observable import Observable, Scalar
+
+
+class AbsoluteTopologicalChargeDensity(Scalar, Observable):
+    r'''The absolute topological-charge density in the four-dimensional
+    :math:`W=1` Villain model.
+
+    For the integer-valued Villain 1-form :math:`n`, define the local
+    topological charge as the 4-form
+
+    .. math::
+
+       Q(x) = (dn \wedge dn)(x).
+
+    On the periodic lattice, :math:`Q=d(n\wedge dn)` is exact, so its signed
+    total vanishes configuration by configuration.  The absolute local charge
+    remains nontrivial: opposite-sign charge defects contribute rather than
+    cancel.  Mirroring :class:`~.ActionDensity`, this observable reports the
+    intensive quantity
+
+    .. math::
+
+       \texttt{AbsoluteTopologicalChargeDensity}
+       = \frac{1}{\Lambda}\sum_x \left|Q(x)\right|,
+
+    where :math:`\Lambda` is the number of four-cells (equivalently, sites) on
+    the periodic four-dimensional hypercubic lattice.
+    '''
+
+    @classmethod
+    def autocorrelation(cls, ensemble):
+        r'''
+        The observable is only defined for the four-dimensional :math:`W=1`
+        Villain model.  Including it in the autocorrelation computation on any
+        other ensemble would trigger a measurement that raises
+        :class:`NotImplementedError`, so we restrict it to the ensembles where it
+        can actually be measured before deferring to the usual :class:`~.Scalar`
+        decision.
+        '''
+        S = ensemble.Action
+        return (
+            isinstance(S, supervillain.action.Villain)
+            and S.Lattice.D == 4
+            and S.W == 1
+            and super().autocorrelation(ensemble)
+        )
+
+    @staticmethod
+    def Villain(S, n):
+        r'''Measure :math:`\Lambda^{-1}\sum_x |(dn\wedge dn)(x)|`.
+
+        This observable is intentionally restricted to the four-dimensional
+        :math:`W=1` model.  The package does not currently define the combined
+        :math:`W>1` and topological-charge-constrained theory.
+        '''
+
+        L = S.Lattice
+        if L.D != 4:
+            raise NotImplementedError(
+                'AbsoluteTopologicalChargeDensity requires a four-dimensional lattice.'
+            )
+        if S.W != 1:
+            raise NotImplementedError(
+                'AbsoluteTopologicalChargeDensity is currently defined only for W=1.'
+            )
+
+        field_strength = d(n)
+        charge = wedge(field_strength, field_strength)
+        return np.abs(charge).sum() / L.cells_of_degree[4]

--- a/supervillain/observable/topological.py
+++ b/supervillain/observable/topological.py
@@ -55,7 +55,7 @@ class TopologicalChargeDensity(Observable):
     a field carrying one value per four-cell.
     It is the per-configuration ingredient from which the other
     topological-charge observables are built: :class:`~.TopologicalCharge` sums
-    it, :class:`~.TopologicalChargeSquared` averages its square, and
+    it, :class:`~.TopologicalChargeDensitySquared` averages its square, and
     :class:`~.TopologicalTwoPoint` autocorrelates it.
 
     Because :math:`Q=d(n\wedge dn)` is exact, its sum over the lattice vanishes
@@ -105,13 +105,13 @@ class TopologicalCharge(Scalar, Observable):
         return TopologicalChargeDensity.sum()
 
 
-class TopologicalChargeSquared(Scalar, Observable):
+class TopologicalChargeDensitySquared(Scalar, Observable):
     r'''The same-site topological-charge correlator in the four-dimensional
     Villain model,
 
     .. math::
 
-       \texttt{TopologicalChargeSquared}
+       \texttt{TopologicalChargeDensitySquared}
        = \frac{1}{\Lambda}\sum_x Q_x^2,
 
     with :math:`\Lambda` the number of four-cells, the intensive same-site value
@@ -163,7 +163,7 @@ class TopologicalTwoPoint(Observable):
     Fourier-accelerated :meth:`~supervillain.lattice.Lattice.correlation`.
 
     Its value at the :py:attr:`~supervillain.lattice.Lattice.origin` equals
-    :class:`~.TopologicalChargeSquared`, and because the total charge vanishes
+    :class:`~.TopologicalChargeDensitySquared`, and because the total charge vanishes
     its sum over :math:`\Delta x` is :math:`\Lambda^{-1}(\sum_x Q_x)^2 = 0`.
     '''
 

--- a/supervillain/observable/topological.py
+++ b/supervillain/observable/topological.py
@@ -55,8 +55,7 @@ class TopologicalChargeDensity(Observable):
     a field carrying one value per four-cell.
     It is the per-configuration ingredient from which the other
     topological-charge observables are built: :class:`~.TopologicalCharge` sums
-    it, :class:`~.AbsoluteTopologicalChargeDensity` averages its magnitude,
-    :class:`~.TopologicalChargeSquared` averages its square, and
+    it, :class:`~.TopologicalChargeSquared` averages its square, and
     :class:`~.TopologicalTwoPoint` autocorrelates it.
 
     Because :math:`Q=d(n\wedge dn)` is exact, its sum over the lattice vanishes
@@ -70,50 +69,6 @@ class TopologicalChargeDensity(Observable):
 
         charge = _topological_charge(S.Lattice, n)
         return np.asarray(charge).sum(axis=0)
-
-
-class AbsoluteTopologicalChargeDensity(Scalar, Observable):
-    r'''The absolute topological-charge density in the four-dimensional Villain
-    model.
-
-    On the periodic lattice the signed charge :math:`Q` (see
-    :class:`~.TopologicalChargeDensity`) is exact, so its signed total vanishes
-    configuration by configuration.  The absolute local charge remains
-    nontrivial: opposite-sign charge defects contribute rather than cancel.
-    Mirroring :class:`~.ActionDensity`, this observable reports the intensive
-    quantity
-
-    .. math::
-
-       \texttt{AbsoluteTopologicalChargeDensity}
-       = \frac{1}{\Lambda}\sum_x \left|Q_x\right|,
-
-    where :math:`\Lambda` is the number of four-cells (equivalently, sites) on
-    the periodic four-dimensional hypercubic lattice.
-    '''
-
-    @classmethod
-    def autocorrelation(cls, ensemble):
-        r'''
-        The observable is only defined for the four-dimensional Villain model, so
-        we restrict the autocorrelation decision to those ensembles before
-        deferring to the usual :class:`~.Scalar` choice.  When :math:`W=\infty`
-        the constraint forces :math:`dn=0`, making the charge an identically-zero
-        constant with no autocorrelation to estimate, so we exclude it there.
-        '''
-        S = ensemble.Action
-        return (
-            isinstance(S, supervillain.action.Villain)
-            and S.Lattice.D == 4
-            and S.W < float('inf')
-            and super().autocorrelation(ensemble)
-        )
-
-    @staticmethod
-    def Villain(S, TopologicalChargeDensity):
-        r'''Measure :math:`\Lambda^{-1}\sum_x |Q_x|` from the charge field.'''
-
-        return np.abs(TopologicalChargeDensity).sum() / S.Lattice.cells_of_degree[4]
 
 
 class TopologicalCharge(Scalar, Observable):
@@ -162,19 +117,21 @@ class TopologicalChargeSquared(Scalar, Observable):
     with :math:`\Lambda` the number of four-cells, the intensive same-site value
     :math:`\langle Q_x^2\rangle`.  Because :math:`\langle Q\rangle = 0` (see
     :class:`~.TopologicalCharge`), this is the local topological-charge
-    fluctuation---the proper, sign-respecting counterpart of
-    :class:`~.AbsoluteTopologicalChargeDensity`.  It equals
-    :class:`~.TopologicalTwoPoint` (equivalently :class:`~.Topological_Topological`)
-    evaluated at the :py:attr:`~supervillain.lattice.Lattice.origin`,
-    configuration by configuration.
+    fluctuation---a proper, sign-respecting measure of local topological
+    activity.  It equals :class:`~.TopologicalTwoPoint` (equivalently
+    :class:`~.Topological_Topological`) evaluated at the
+    :py:attr:`~supervillain.lattice.Lattice.origin`, configuration by
+    configuration.
     '''
 
     @classmethod
     def autocorrelation(cls, ensemble):
         r'''
-        Defined only for the four-dimensional Villain model; excluded when
-        :math:`W=\infty` because the charge is then identically zero.  See
-        :meth:`AbsoluteTopologicalChargeDensity.autocorrelation`.
+        The observable is only defined for the four-dimensional Villain model, so
+        we restrict the autocorrelation decision to those ensembles before
+        deferring to the usual :class:`~.Scalar` choice.  When :math:`W=\infty`
+        the constraint forces :math:`dn=0`, making the charge an identically-zero
+        constant with no autocorrelation to estimate, so we exclude it there.
         '''
         S = ensemble.Action
         return (

--- a/supervillain/observable/topological.py
+++ b/supervillain/observable/topological.py
@@ -8,22 +8,22 @@ from supervillain.observable import Observable, Scalar, DerivedQuantity
 
 
 def _topological_charge(L, n):
-    r'''The local topological charge.
+    r'''The local topological-charge density.
 
-    For the integer-valued Villain 1-form :math:`n`, the local topological
-    charge is the 4-form
+    For the integer-valued Villain 1-form :math:`n`, the local topological-charge
+    density is the 4-form
 
     .. math::
 
-       Q_x = (dn \wedge dn)_x.
+       q_x = (dn \wedge dn)_x.
 
-    It is a 4-form, so it is only the top form---and therefore the global
-    topological charge density---on a four-dimensional lattice.  We restrict to
-    :math:`D=4`; the :math:`W` constraint :math:`[dn \equiv 0 \bmod W]` is
-    irrelevant to the *measurement*: when :math:`W>1` the field strength
-    :math:`dn` is quantized in units of :math:`W` (so :math:`Q` comes in units
-    of :math:`W^2`), and when :math:`W=\infty` the constraint forces
-    :math:`dn=0` so :math:`Q\equiv 0`.
+    It is a 4-form, so it is the top form only on a four-dimensional lattice,
+    where its lattice sum is the global topological charge :math:`Q = \sum_x q_x`.
+    We restrict to :math:`D=4`; the :math:`W` constraint
+    :math:`[dn \equiv 0 \bmod W]` is irrelevant to the *measurement*: when
+    :math:`W>1` the field strength :math:`dn` is quantized in units of :math:`W`
+    (so :math:`q` comes in units of :math:`W^2`), and when :math:`W=\infty` the
+    constraint forces :math:`dn=0` so :math:`q\equiv 0`.
 
     Parameters
     ----------
@@ -34,7 +34,7 @@ def _topological_charge(L, n):
     Returns
     -------
     np.ndarray
-        The charge 4-form, shape ``(1,) + L.dims``.
+        The charge-density 4-form, shape ``(1,) + L.dims``.
     '''
     if L.D != 4:
         raise NotImplementedError(
@@ -50,7 +50,7 @@ class TopologicalChargeDensity(Observable):
 
     .. math::
 
-       \texttt{TopologicalChargeDensity}_x = Q_x = (dn\wedge dn)_x,
+       \texttt{TopologicalChargeDensity}_x = q_x = (dn\wedge dn)_x,
 
     a field carrying one value per four-cell.
     It is the per-configuration ingredient from which the other
@@ -58,14 +58,14 @@ class TopologicalChargeDensity(Observable):
     it, :class:`~.TopologicalChargeDensitySquared` averages its square, and
     :class:`~.TopologicalTwoPoint` autocorrelates it.
 
-    Because :math:`Q=d(n\wedge dn)` is exact, its sum over the lattice vanishes
-    configuration by configuration, so :math:`\langle Q_x\rangle = 0` pointwise
-    by translation invariance.
+    Because :math:`q=d(n\wedge dn)` is exact, its lattice sum---the total charge
+    :math:`Q`---vanishes configuration by configuration, so
+    :math:`\langle q_x\rangle = 0` pointwise by translation invariance.
     '''
 
     @staticmethod
     def Villain(S, n):
-        r'''Measure the charge field :math:`Q_x = (dn\wedge dn)_x`.'''
+        r'''Measure the charge-density field :math:`q_x = (dn\wedge dn)_x`.'''
 
         charge = _topological_charge(S.Lattice, n)
         return np.asarray(charge).sum(axis=0)
@@ -77,15 +77,16 @@ class TopologicalCharge(Scalar, Observable):
 
     .. math::
 
-       \texttt{TopologicalCharge} = \sum_x Q_x,
+       \texttt{TopologicalCharge} = Q = \sum_x q_x,
 
-    the lattice sum of :class:`~.TopologicalChargeDensity`.  Because the charge
-    density is exact this vanishes identically on the periodic lattice---
+    the lattice sum of :class:`~.TopologicalChargeDensity`.  Because the density
+    :math:`q` is exact this vanishes identically on the periodic lattice---
     configuration by configuration, for every :math:`W`.  It is therefore
-    pointless to measure on its own, but it is the :math:`\langle Q\rangle` that
-    would form the quantum-disconnected piece of
-    :class:`~.Topological_Topological` were the charge to develop a nonzero
-    expectation value (for instance under a topological chemical potential).
+    pointless to measure on its own; a nonzero :math:`\langle Q\rangle`
+    (equivalently a nonzero density expectation
+    :math:`\langle q_x\rangle = \langle Q\rangle/\Lambda`) is what would let the
+    quantum-disconnected piece of :class:`~.Topological_Topological` survive (for
+    instance under a topological chemical potential).
     '''
 
     @classmethod
@@ -99,8 +100,8 @@ class TopologicalCharge(Scalar, Observable):
 
     @staticmethod
     def Villain(S, TopologicalChargeDensity):
-        r'''Measure :math:`\sum_x Q_x`, the lattice sum of the charge field
-        (always zero).'''
+        r'''Measure :math:`Q = \sum_x q_x`, the lattice sum of the charge-density
+        field (always zero).'''
 
         return TopologicalChargeDensity.sum()
 
@@ -112,14 +113,14 @@ class TopologicalChargeDensitySquared(Scalar, Observable):
     .. math::
 
        \texttt{TopologicalChargeDensitySquared}
-       = \frac{1}{\Lambda}\sum_x Q_x^2,
+       = \frac{1}{\Lambda}\sum_x q_x^2,
 
     with :math:`\Lambda` the number of four-cells, the intensive same-site value
-    :math:`\langle Q_x^2\rangle`.  Because :math:`\langle Q\rangle = 0` (see
-    :class:`~.TopologicalCharge`), this is the local topological-charge
-    fluctuation---a proper, sign-respecting measure of local topological
-    activity.  It equals :class:`~.TopologicalTwoPoint` (equivalently
-    :class:`~.Topological_Topological`) evaluated at the
+    :math:`\langle q_x^2\rangle`.  Because :math:`\langle q_x\rangle = 0` (the
+    total charge :math:`Q` vanishes; see :class:`~.TopologicalCharge`), this is
+    the local topological-charge fluctuation---a proper, sign-respecting measure
+    of local topological activity.  It equals :class:`~.TopologicalTwoPoint`
+    (equivalently :class:`~.Topological_Topological`) evaluated at the
     :py:attr:`~supervillain.lattice.Lattice.origin`, configuration by
     configuration.
     '''
@@ -143,33 +144,34 @@ class TopologicalChargeDensitySquared(Scalar, Observable):
 
     @staticmethod
     def Villain(S, TopologicalChargeDensity):
-        r'''Measure :math:`\Lambda^{-1}\sum_x Q_x^2` from the charge field.  The
-        field has one entry per four-cell, so the mean is the average over the
-        :math:`\Lambda` four-cells.'''
+        r'''Measure :math:`\Lambda^{-1}\sum_x q_x^2` from the charge-density field.
+        The field has one entry per four-cell, so the mean is the average over
+        the :math:`\Lambda` four-cells.'''
 
         return np.mean(TopologicalChargeDensity ** 2)
 
 
 class TopologicalTwoPoint(Observable):
-    r'''The translation-averaged two-point function of the local topological
-    charge in the four-dimensional Villain model,
+    r'''The translation-averaged two-point function of the local topological-charge
+    density in the four-dimensional Villain model,
 
     .. math::
 
        \texttt{TopologicalTwoPoint}_{\Delta x}
-       = \frac{1}{\Lambda}\sum_x Q_x\,Q_{x-\Delta x},
+       = \frac{1}{\Lambda}\sum_x q_x\,q_{x-\Delta x},
 
     the autocorrelation of :class:`~.TopologicalChargeDensity` computed with the
     Fourier-accelerated :meth:`~supervillain.lattice.Lattice.correlation`.
 
     Its value at the :py:attr:`~supervillain.lattice.Lattice.origin` equals
-    :class:`~.TopologicalChargeDensitySquared`, and because the total charge vanishes
-    its sum over :math:`\Delta x` is :math:`\Lambda^{-1}(\sum_x Q_x)^2 = 0`.
+    :class:`~.TopologicalChargeDensitySquared`, and because the total charge
+    vanishes its sum over :math:`\Delta x` is
+    :math:`\Lambda^{-1}(\sum_x q_x)^2 = \Lambda^{-1}Q^2 = 0`.
     '''
 
     @staticmethod
     def Villain(S, TopologicalChargeDensity):
-        r'''Measure :math:`\Lambda^{-1}\sum_x Q_x\,Q_{x-\Delta x}` from the charge field.'''
+        r'''Measure :math:`\Lambda^{-1}\sum_x q_x\,q_{x-\Delta x}` from the charge-density field.'''
 
         return S.Lattice.correlation(TopologicalChargeDensity, TopologicalChargeDensity)
 
@@ -183,20 +185,21 @@ class Topological_Topological(DerivedQuantity):
         \begin{aligned}
             \texttt{Topological\_Topological}_{\Delta x}
             &= \frac{1}{\Lambda}\sum_x \left(
-                \langle Q_x Q_{x-\Delta x}\rangle - \langle Q_x\rangle\langle Q_{x-\Delta x}\rangle
+                \langle q_x q_{x-\Delta x}\rangle - \langle q_x\rangle\langle q_{x-\Delta x}\rangle
                 \right)
             \\
             &= \texttt{TopologicalTwoPoint}_{\Delta x}
-                - \texttt{correlation}(\langle Q\rangle, \langle Q\rangle)_{\Delta x}.
+                - \texttt{correlation}(\langle q\rangle, \langle q\rangle)_{\Delta x}.
         \end{aligned}
 
     Both terms are normalized the same way.
 
-    On the periodic lattice the total charge :math:`\sum_x Q_x = 0` configuration by
-    configuration (see :class:`~.TopologicalCharge`), so translation invariance forces
-    :math:`\langle Q_x\rangle = 0` and the disconnected piece vanishes in expectation;
-    the subtraction is retained so that it is restored automatically should the charge
-    ever acquire a nonzero expectation value.
+    On the periodic lattice the total charge :math:`Q = \sum_x q_x = 0`
+    configuration by configuration (see :class:`~.TopologicalCharge`), so
+    translation invariance forces :math:`\langle q_x\rangle = 0` and the
+    disconnected piece vanishes in expectation; the subtraction is retained so
+    that it is restored automatically should the charge ever acquire a nonzero
+    expectation value.
     '''
 
     @staticmethod

--- a/supervillain/observable/topological.py
+++ b/supervillain/observable/topological.py
@@ -4,30 +4,89 @@ import numpy as np
 
 import supervillain.action
 from supervillain.lattice import d, wedge
-from supervillain.observable import Observable, Scalar
+from supervillain.observable import Observable, Scalar, DerivedQuantity
 
 
-class AbsoluteTopologicalChargeDensity(Scalar, Observable):
-    r'''The absolute topological-charge density in the four-dimensional
-    :math:`W=1` Villain model.
+def _topological_charge(L, n):
+    r'''The local topological charge.
 
-    For the integer-valued Villain 1-form :math:`n`, define the local
-    topological charge as the 4-form
+    For the integer-valued Villain 1-form :math:`n`, the local topological
+    charge is the 4-form
 
     .. math::
 
-       Q(x) = (dn \wedge dn)(x).
+       Q_x = (dn \wedge dn)_x.
 
-    On the periodic lattice, :math:`Q=d(n\wedge dn)` is exact, so its signed
-    total vanishes configuration by configuration.  The absolute local charge
-    remains nontrivial: opposite-sign charge defects contribute rather than
-    cancel.  Mirroring :class:`~.ActionDensity`, this observable reports the
-    intensive quantity
+    It is a 4-form, so it is only the top form---and therefore the global
+    topological charge density---on a four-dimensional lattice.  We restrict to
+    :math:`D=4`; the :math:`W` constraint :math:`[dn \equiv 0 \bmod W]` is
+    irrelevant to the *measurement*: when :math:`W>1` the field strength
+    :math:`dn` is quantized in units of :math:`W` (so :math:`Q` comes in units
+    of :math:`W^2`), and when :math:`W=\infty` the constraint forces
+    :math:`dn=0` so :math:`Q\equiv 0`.
+
+    Parameters
+    ----------
+    L : supervillain.lattice.Lattice
+    n : np.ndarray
+        An integer-valued 1-form.
+
+    Returns
+    -------
+    np.ndarray
+        The charge 4-form, shape ``(1,) + L.dims``.
+    '''
+    if L.D != 4:
+        raise NotImplementedError(
+            'Topological-charge observables require a four-dimensional lattice.'
+        )
+    field_strength = d(n)
+    return wedge(field_strength, field_strength)
+
+
+class TopologicalChargeDensity(Observable):
+    r'''The local topological-charge density in the four-dimensional Villain
+    model,
+
+    .. math::
+
+       \texttt{TopologicalChargeDensity}_x = Q_x = (dn\wedge dn)_x,
+
+    a field carrying one value per four-cell.
+    It is the per-configuration ingredient from which the other
+    topological-charge observables are built: :class:`~.TopologicalCharge` sums
+    it, :class:`~.AbsoluteTopologicalChargeDensity` averages its magnitude,
+    :class:`~.TopologicalChargeSquared` averages its square, and
+    :class:`~.TopologicalTwoPoint` autocorrelates it.
+
+    Because :math:`Q=d(n\wedge dn)` is exact, its sum over the lattice vanishes
+    configuration by configuration, so :math:`\langle Q_x\rangle = 0` pointwise
+    by translation invariance.
+    '''
+
+    @staticmethod
+    def Villain(S, n):
+        r'''Measure the charge field :math:`Q_x = (dn\wedge dn)_x`.'''
+
+        charge = _topological_charge(S.Lattice, n)
+        return np.asarray(charge).sum(axis=0)
+
+
+class AbsoluteTopologicalChargeDensity(Scalar, Observable):
+    r'''The absolute topological-charge density in the four-dimensional Villain
+    model.
+
+    On the periodic lattice the signed charge :math:`Q` (see
+    :class:`~.TopologicalChargeDensity`) is exact, so its signed total vanishes
+    configuration by configuration.  The absolute local charge remains
+    nontrivial: opposite-sign charge defects contribute rather than cancel.
+    Mirroring :class:`~.ActionDensity`, this observable reports the intensive
+    quantity
 
     .. math::
 
        \texttt{AbsoluteTopologicalChargeDensity}
-       = \frac{1}{\Lambda}\sum_x \left|Q(x)\right|,
+       = \frac{1}{\Lambda}\sum_x \left|Q_x\right|,
 
     where :math:`\Lambda` is the number of four-cells (equivalently, sites) on
     the periodic four-dimensional hypercubic lattice.
@@ -36,40 +95,154 @@ class AbsoluteTopologicalChargeDensity(Scalar, Observable):
     @classmethod
     def autocorrelation(cls, ensemble):
         r'''
-        The observable is only defined for the four-dimensional :math:`W=1`
-        Villain model.  Including it in the autocorrelation computation on any
-        other ensemble would trigger a measurement that raises
-        :class:`NotImplementedError`, so we restrict it to the ensembles where it
-        can actually be measured before deferring to the usual :class:`~.Scalar`
-        decision.
+        The observable is only defined for the four-dimensional Villain model, so
+        we restrict the autocorrelation decision to those ensembles before
+        deferring to the usual :class:`~.Scalar` choice.  When :math:`W=\infty`
+        the constraint forces :math:`dn=0`, making the charge an identically-zero
+        constant with no autocorrelation to estimate, so we exclude it there.
         '''
         S = ensemble.Action
         return (
             isinstance(S, supervillain.action.Villain)
             and S.Lattice.D == 4
-            and S.W == 1
+            and S.W < float('inf')
             and super().autocorrelation(ensemble)
         )
 
     @staticmethod
-    def Villain(S, n):
-        r'''Measure :math:`\Lambda^{-1}\sum_x |(dn\wedge dn)(x)|`.
+    def Villain(S, TopologicalChargeDensity):
+        r'''Measure :math:`\Lambda^{-1}\sum_x |Q_x|` from the charge field.'''
 
-        This observable is intentionally restricted to the four-dimensional
-        :math:`W=1` model.  The package does not currently define the combined
-        :math:`W>1` and topological-charge-constrained theory.
+        return np.abs(TopologicalChargeDensity).sum() / S.Lattice.cells_of_degree[4]
+
+
+class TopologicalCharge(Scalar, Observable):
+    r'''The signed total topological charge in the four-dimensional Villain
+    model,
+
+    .. math::
+
+       \texttt{TopologicalCharge} = \sum_x Q_x,
+
+    the lattice sum of :class:`~.TopologicalChargeDensity`.  Because the charge
+    density is exact this vanishes identically on the periodic lattice---
+    configuration by configuration, for every :math:`W`.  It is therefore
+    pointless to measure on its own, but it is the :math:`\langle Q\rangle` that
+    would form the quantum-disconnected piece of
+    :class:`~.Topological_Topological` were the charge to develop a nonzero
+    expectation value (for instance under a topological chemical potential).
+    '''
+
+    @classmethod
+    def autocorrelation(cls, ensemble):
+        r'''
+        The total charge is identically zero on every configuration, so it has
+        no fluctuations and is never included in the autocorrelation-time
+        computation.
         '''
+        return False
 
+    @staticmethod
+    def Villain(S, TopologicalChargeDensity):
+        r'''Measure :math:`\sum_x Q_x`, the lattice sum of the charge field
+        (always zero).'''
+
+        return TopologicalChargeDensity.sum()
+
+
+class TopologicalChargeSquared(Scalar, Observable):
+    r'''The same-site topological-charge correlator in the four-dimensional
+    Villain model,
+
+    .. math::
+
+       \texttt{TopologicalChargeSquared}
+       = \frac{1}{\Lambda}\sum_x Q_x^2,
+
+    with :math:`\Lambda` the number of four-cells, the intensive same-site value
+    :math:`\langle Q_x^2\rangle`.  Because :math:`\langle Q\rangle = 0` (see
+    :class:`~.TopologicalCharge`), this is the local topological-charge
+    fluctuation---the proper, sign-respecting counterpart of
+    :class:`~.AbsoluteTopologicalChargeDensity`.  It equals
+    :class:`~.TopologicalTwoPoint` (equivalently :class:`~.Topological_Topological`)
+    evaluated at the :py:attr:`~supervillain.lattice.Lattice.origin`,
+    configuration by configuration.
+    '''
+
+    @classmethod
+    def autocorrelation(cls, ensemble):
+        r'''
+        Defined only for the four-dimensional Villain model; excluded when
+        :math:`W=\infty` because the charge is then identically zero.  See
+        :meth:`AbsoluteTopologicalChargeDensity.autocorrelation`.
+        '''
+        S = ensemble.Action
+        return (
+            isinstance(S, supervillain.action.Villain)
+            and S.Lattice.D == 4
+            and S.W < float('inf')
+            and super().autocorrelation(ensemble)
+        )
+
+    @staticmethod
+    def Villain(S, TopologicalChargeDensity):
+        r'''Measure :math:`\Lambda^{-1}\sum_x Q_x^2` from the charge field.  The
+        field has one entry per four-cell, so the mean is the average over the
+        :math:`\Lambda` four-cells.'''
+
+        return np.mean(TopologicalChargeDensity ** 2)
+
+
+class TopologicalTwoPoint(Observable):
+    r'''The translation-averaged two-point function of the local topological
+    charge in the four-dimensional Villain model,
+
+    .. math::
+
+       \texttt{TopologicalTwoPoint}_{\Delta x}
+       = \frac{1}{\Lambda}\sum_x Q_x\,Q_{x-\Delta x},
+
+    the autocorrelation of :class:`~.TopologicalChargeDensity` computed with the
+    Fourier-accelerated :meth:`~supervillain.lattice.Lattice.correlation`.
+
+    Its value at the :py:attr:`~supervillain.lattice.Lattice.origin` equals
+    :class:`~.TopologicalChargeSquared`, and because the total charge vanishes
+    its sum over :math:`\Delta x` is :math:`\Lambda^{-1}(\sum_x Q_x)^2 = 0`.
+    '''
+
+    @staticmethod
+    def Villain(S, TopologicalChargeDensity):
+        r'''Measure :math:`\Lambda^{-1}\sum_x Q_x\,Q_{x-\Delta x}` from the charge field.'''
+
+        return S.Lattice.correlation(TopologicalChargeDensity, TopologicalChargeDensity)
+
+
+class Topological_Topological(DerivedQuantity):
+    r'''The connected topological-charge correlator: the translation average of
+    the connected two-point function,
+
+    .. math::
+
+        \begin{aligned}
+            \texttt{Topological\_Topological}_{\Delta x}
+            &= \frac{1}{\Lambda}\sum_x \left(
+                \langle Q_x Q_{x-\Delta x}\rangle - \langle Q_x\rangle\langle Q_{x-\Delta x}\rangle
+                \right)
+            \\
+            &= \texttt{TopologicalTwoPoint}_{\Delta x}
+                - \texttt{correlation}(\langle Q\rangle, \langle Q\rangle)_{\Delta x}.
+        \end{aligned}
+
+    Both terms are normalized the same way.
+
+    On the periodic lattice the total charge :math:`\sum_x Q_x = 0` configuration by
+    configuration (see :class:`~.TopologicalCharge`), so translation invariance forces
+    :math:`\langle Q_x\rangle = 0` and the disconnected piece vanishes in expectation;
+    the subtraction is retained so that it is restored automatically should the charge
+    ever acquire a nonzero expectation value.
+    '''
+
+    @staticmethod
+    def default(S, TopologicalTwoPoint, TopologicalChargeDensity):
         L = S.Lattice
-        if L.D != 4:
-            raise NotImplementedError(
-                'AbsoluteTopologicalChargeDensity requires a four-dimensional lattice.'
-            )
-        if S.W != 1:
-            raise NotImplementedError(
-                'AbsoluteTopologicalChargeDensity is currently defined only for W=1.'
-            )
-
-        field_strength = d(n)
-        charge = wedge(field_strength, field_strength)
-        return np.abs(charge).sum() / L.cells_of_degree[4]
+        return TopologicalTwoPoint - L.correlation(TopologicalChargeDensity, TopologicalChargeDensity)

--- a/test/test_topological_charge.py
+++ b/test/test_topological_charge.py
@@ -6,7 +6,14 @@ import pytest
 import supervillain
 from supervillain.batch import Batch
 from supervillain.lattice import d, wedge
-from supervillain.observable.topological import AbsoluteTopologicalChargeDensity
+from supervillain.observable.topological import (
+    AbsoluteTopologicalChargeDensity,
+    TopologicalChargeDensity,
+    TopologicalCharge,
+    TopologicalChargeSquared,
+    TopologicalTwoPoint,
+    Topological_Topological,
+)
 
 
 def unit_charge_dipole(L):
@@ -22,11 +29,118 @@ def unit_charge_dipole(L):
     return n
 
 
+def charge_density(S, n):
+    r'''The per-configuration charge field Q_x, the ingredient the downstream
+    observables consume.'''
+    return TopologicalChargeDensity.Villain(S, n)
+
+
+def brute_force_correlation(L, f, g):
+    r'''An independent, FFT-free real-space evaluation of the translation-averaged
+    correlator (1/Λ) ∑_x f(x) g(x-Δx), matching the convention of
+    :meth:`~supervillain.lattice.Lattice.correlation`.'''
+    f = np.asarray(f)
+    g = np.asarray(g)
+    axes = tuple(range(L.D))
+    C = np.zeros(L.dims)
+    for shift in np.ndindex(*L.dims):
+        C[shift] = (f * np.roll(g, shift, axis=axes)).sum() / L.sites
+    return C
+
+
+# ---------------------------------------------------------------------------
+# TopologicalChargeDensity: the per-configuration field Q_x, the ingredient
+# from which the other observables are built.  It is the only observable that
+# depends on n; the rest consume it.
+# ---------------------------------------------------------------------------
+
+def test_topological_charge_density_equals_exact_form_d_of_n_wedge_dn():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(20260629)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    density = TopologicalChargeDensity.Villain(S, n)
+    assert density.shape == L.dims
+
+    # Independent path: Q = dn∧dn = d(n∧dn) by the Leibniz rule (since ddn = 0).
+    # The observable forms dn first and then wedges; here we wedge first (n∧dn)
+    # and then take d, a genuinely different sequence of operations.
+    exact_form = np.asarray(d(wedge(n, d(n)))).sum(axis=0)
+    assert np.array_equal(density, exact_form)
+
+
+def test_topological_charge_density_is_bilinear():
+    # Q = dn∧dn is quadratic in n, so scaling n by an integer c scales Q by c².
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(31415)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    base = TopologicalChargeDensity.Villain(S, n)
+    for c in (2, 3, -2):
+        scaled = TopologicalChargeDensity.Villain(S, c * n)
+        assert np.array_equal(scaled, c ** 2 * base)
+
+
+def test_topological_charge_density_for_dipole():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+    density = TopologicalChargeDensity.Villain(S, unit_charge_dipole(L))
+
+    assert np.array_equal(np.sort(density[density != 0]), [-1, 1])
+    assert density.sum() == 0
+
+
+@pytest.mark.parametrize('D', [3, 5])
+def test_topological_charge_density_rejects_non_four_dimensions(D):
+    # The topological charge dn∧dn is a 4-form; only in D=4 is it the top form
+    # whose integral is the global charge.  TopologicalChargeDensity is the
+    # gatekeeper: the downstream observables consume it and inherit the restriction.
+    L = supervillain.lattice.Lattice(D=D, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+
+    with pytest.raises(NotImplementedError):
+        TopologicalChargeDensity.Villain(S, L.zeros(1, dtype=int))
+
+
+@pytest.mark.parametrize('D', [3, 5])
+@pytest.mark.parametrize('name', [
+    'TopologicalChargeDensity',
+    'AbsoluteTopologicalChargeDensity',
+    'TopologicalCharge',
+    'TopologicalChargeSquared',
+    'TopologicalTwoPoint',
+])
+def test_topological_observables_reject_non_four_dimensions_via_ensemble(D, name):
+    # Measuring any topological observable on a non-4D ensemble fails because the
+    # TopologicalChargeDensity ingredient raises.  (ensemble.measure swallows the
+    # NotImplementedError and skips, so we trigger the measurement via attribute
+    # access, which propagates it.)
+    L = supervillain.lattice.Lattice(D=D, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+    configurations = S.configurations(1)
+    configurations[0] = {'phi': L.zeros(0), 'n': L.zeros(1, dtype=int)}
+    ensemble = supervillain.Ensemble(S).from_configurations(configurations)
+
+    with pytest.raises(NotImplementedError):
+        getattr(ensemble, name)
+
+    # measure() skips unimplemented observables rather than raising.
+    assert name not in ensemble.measure([name])
+
+
+# ---------------------------------------------------------------------------
+# AbsoluteTopologicalChargeDensity: Λ⁻¹∑|Q(x)|.
+# ---------------------------------------------------------------------------
+
 def test_absolute_topological_charge_density_vacuum_is_zero():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=1)
 
-    assert AbsoluteTopologicalChargeDensity.Villain(S, L.zeros(1, dtype=int)) == 0
+    assert AbsoluteTopologicalChargeDensity.Villain(S, charge_density(S, L.zeros(1, dtype=int))) == 0
 
 
 @pytest.mark.parametrize('kappa', [0.05, 0.5, 2.0])
@@ -34,12 +148,12 @@ def test_absolute_topological_charge_density_counts_unit_charge_dipole(kappa):
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=kappa, W=1)
     n = unit_charge_dipole(L)
-    charge = wedge(d(n), d(n))
+    density = charge_density(S, n)
 
-    assert np.array_equal(np.sort(np.asarray(charge)[charge != 0]), [-1, 1])
-    assert charge.sum() == 0
-    assert np.abs(charge).sum() == 2
-    assert AbsoluteTopologicalChargeDensity.Villain(S, n) == 2 / L.sites
+    assert np.array_equal(np.sort(density[density != 0]), [-1, 1])
+    assert density.sum() == 0
+    assert np.abs(density).sum() == 2
+    assert AbsoluteTopologicalChargeDensity.Villain(S, density) == 2 / L.cells_of_degree[4]
 
 
 def test_absolute_topological_charge_density_matches_wedge_definition():
@@ -48,13 +162,13 @@ def test_absolute_topological_charge_density_matches_wedge_definition():
     rng = np.random.default_rng(20260629)
     n = L.zeros(1, dtype=int)
     n[...] = rng.integers(-2, 3, size=n.shape)
+    density = charge_density(S, n)
 
-    charge = wedge(d(n), d(n))
-    expected = np.abs(charge).sum() / L.cells_of_degree[4]
-    measured = AbsoluteTopologicalChargeDensity.Villain(S, n)
+    expected = np.abs(density).sum() / L.cells_of_degree[4]
+    measured = AbsoluteTopologicalChargeDensity.Villain(S, density)
 
     # Q is exact on the periodic lattice, while its L1 norm is nonzero.
-    assert charge.sum() == 0
+    assert density.sum() == 0
     assert expected > 0
     assert measured == expected
 
@@ -70,8 +184,8 @@ def test_absolute_topological_charge_density_is_gauge_invariant():
 
     transformed = S.gauge_transform({'phi': phi, 'n': n}, k)
 
-    before = AbsoluteTopologicalChargeDensity.Villain(S, n)
-    after = AbsoluteTopologicalChargeDensity.Villain(S, transformed['n'])
+    before = AbsoluteTopologicalChargeDensity.Villain(S, charge_density(S, n))
+    after = AbsoluteTopologicalChargeDensity.Villain(S, charge_density(S, transformed['n']))
     assert after == before
 
 
@@ -97,16 +211,258 @@ def test_absolute_topological_charge_density_integrates_with_ensemble():
 
     assert isinstance(values, Batch)
     assert values.shape == (2,)
-    assert np.array_equal(Batch.as_array(values), [0, 2 / L.sites])
+    assert np.array_equal(Batch.as_array(values), [0, 2 / L.cells_of_degree[4]])
     assert ensemble.AbsoluteTopologicalChargeDensity is values
     assert 'AbsoluteTopologicalChargeDensity' in ensemble.measured
+    # The density ingredient was measured and cached as a side effect.
+    assert 'TopologicalChargeDensity' in ensemble.measured
     assert AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
 
 
-@pytest.mark.parametrize(('D', 'W'), [(3, 1), (4, 2)])
-def test_absolute_topological_charge_density_rejects_unsupported_models(D, W):
-    L = supervillain.lattice.Lattice(D=D, N=3)
+# ---------------------------------------------------------------------------
+# TopologicalCharge: the signed total Q_total = ∑_x Q_x, a per-configuration
+# Observable that sums the density.  Identically zero.
+# ---------------------------------------------------------------------------
+
+def test_topological_charge_sums_the_density_to_zero():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(20260629)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    for cfg in (L.zeros(1, dtype=int), unit_charge_dipole(L), n):
+        density = charge_density(S, cfg)
+        # Independent total via the exact form Q = d(n∧dn): a sum of an exact
+        # form over the closed lattice, so it must vanish identically.
+        exact_total = np.asarray(d(wedge(cfg, d(cfg)))).sum()
+        assert TopologicalCharge.Villain(S, density) == exact_total
+        assert TopologicalCharge.Villain(S, density) == 0
+
+
+# ---------------------------------------------------------------------------
+# TopologicalChargeSquared: the same-site value χ_0 = ⟨Q_x²⟩.
+# ---------------------------------------------------------------------------
+
+def test_topological_charge_squared_vacuum_is_zero():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+
+    assert TopologicalChargeSquared.Villain(S, charge_density(S, L.zeros(1, dtype=int))) == 0
+
+
+def test_topological_charge_squared_counts_unit_charge_dipole():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+    density = charge_density(S, unit_charge_dipole(L))
+
+    # Q is ±1 on two 4-cells, so Q² is 1 on two cells and the mean is 2/Λ.
+    assert TopologicalChargeSquared.Villain(S, density) == 2 / L.cells_of_degree[4]
+
+
+def test_topological_charge_squared_equals_brute_force_origin_correlation():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(11)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+    density = charge_density(S, n)
+
+    # χ_0 = Λ⁻¹∑_x Q_x² is the same-site value of the real-space correlator;
+    # check it against the independent brute-force correlation at Δx = 0.
+    expected = brute_force_correlation(L, density, density)[L.origin]
+    assert np.isclose(TopologicalChargeSquared.Villain(S, density), expected)
+    assert expected > 0
+
+
+# ---------------------------------------------------------------------------
+# TopologicalTwoPoint: the Δx-resolved correlator ⟨Q_x Q_{x-Δx}⟩.
+# ---------------------------------------------------------------------------
+
+def test_topological_two_point_matches_brute_force_real_space():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(7)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+    density = charge_density(S, n)
+
+    two_point = np.asarray(TopologicalTwoPoint.Villain(S, density))
+    assert two_point.shape == L.dims
+
+    # Independent of the FFT-accelerated L.correlation: brute-force real-space sum.
+    assert np.allclose(two_point, brute_force_correlation(L, density, density))
+
+
+def test_topological_two_point_origin_equals_charge_squared():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(8)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+    density = charge_density(S, n)
+
+    two_point = np.asarray(TopologicalTwoPoint.Villain(S, density))
+    assert np.isclose(two_point[L.origin], TopologicalChargeSquared.Villain(S, density))
+
+
+def test_topological_two_point_sums_to_zero_because_total_charge_vanishes():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(9)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    # ∑_Δx ⟨Q_x Q_{x-Δx}⟩ = (1/Λ)(∑_x Q_x)² = 0 since Q_total = 0.
+    two_point = np.asarray(TopologicalTwoPoint.Villain(S, charge_density(S, n)))
+    assert np.isclose(two_point.sum(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Topological_Topological: connected correlator = TwoPoint − ⟨Q⟩⊗⟨Q⟩ correlation.
+# ---------------------------------------------------------------------------
+
+def test_topological_topological_subtracts_density_disconnected_piece():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(99)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    density = charge_density(S, n)
+    two_point = np.asarray(TopologicalTwoPoint.Villain(S, density))
+
+    # Independent disconnected piece via the brute-force real-space correlation.
+    expected = two_point - brute_force_correlation(L, density, density)
+    result = np.asarray(Topological_Topological.default(S, two_point, density))
+    assert np.allclose(result, expected)
+
+
+def test_topological_topological_equals_two_point_when_density_expectation_vanishes():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(100)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    two_point = np.asarray(TopologicalTwoPoint.Villain(S, charge_density(S, n)))
+    # With ⟨Q⟩ = 0 the disconnected piece vanishes and the connected correlator
+    # is exactly the two-point function.
+    zero_density = charge_density(S, L.zeros(1, dtype=int))
+    result = np.asarray(Topological_Topological.default(S, two_point, zero_density))
+    assert np.array_equal(result, two_point)
+
+
+# ---------------------------------------------------------------------------
+# W is no longer restricted to 1: any finite W works (charge quantized in W²),
+# and W=∞ (dn=0) measures a well-defined zero.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('W', [2, 3])
+def test_topological_observables_allow_finite_W_greater_than_one(W):
+    L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=W)
 
-    with pytest.raises(NotImplementedError):
-        AbsoluteTopologicalChargeDensity.Villain(S, L.zeros(1, dtype=int))
+    # W·(unit dipole) has dn ∈ Wℤ, a valid W>1 configuration; its charge scales by W².
+    n = W * unit_charge_dipole(L)
+    assert S.valid({'n': n})
+
+    density = charge_density(S, n)
+    assert np.abs(density).sum() == 2 * W ** 2
+    assert density.sum() == 0
+
+    assert TopologicalCharge.Villain(S, density) == 0
+    assert AbsoluteTopologicalChargeDensity.Villain(S, density) == 2 * W ** 2 / L.cells_of_degree[4]
+    assert TopologicalChargeSquared.Villain(S, density) == 2 * W ** 4 / L.cells_of_degree[4]
+    assert np.asarray(TopologicalTwoPoint.Villain(S, density)).shape == L.dims
+
+
+def test_topological_observables_W_infinite_measure_zero():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=float('inf'))
+
+    # W=∞ forces dn=0, so every valid configuration has vanishing charge.
+    n = L.zeros(1, dtype=int)
+    assert S.valid({'n': n})
+
+    density = charge_density(S, n)
+    assert np.all(density == 0)
+    assert TopologicalCharge.Villain(S, density) == 0
+    assert AbsoluteTopologicalChargeDensity.Villain(S, density) == 0
+    assert TopologicalChargeSquared.Villain(S, density) == 0
+    assert np.all(np.asarray(TopologicalTwoPoint.Villain(S, density)) == 0)
+
+
+# ---------------------------------------------------------------------------
+# Gauge invariance of the new observables.
+# ---------------------------------------------------------------------------
+
+def test_new_topological_observables_are_gauge_invariant():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    n = unit_charge_dipole(L)
+    phi = L.zeros(0)
+    k = L.zeros(0, dtype=int)
+    rng = np.random.default_rng(4321)
+    k[...] = rng.integers(-3, 4, size=k.shape)
+
+    transformed = S.gauge_transform({'phi': phi, 'n': n}, k)
+    density = charge_density(S, n)
+    density_transformed = charge_density(S, transformed['n'])
+
+    assert np.array_equal(density_transformed, density)
+    assert TopologicalChargeSquared.Villain(S, density_transformed) == TopologicalChargeSquared.Villain(S, density)
+    assert np.allclose(
+        np.asarray(TopologicalTwoPoint.Villain(S, density_transformed)),
+        np.asarray(TopologicalTwoPoint.Villain(S, density)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration and autocorrelation inclusion.
+# ---------------------------------------------------------------------------
+
+def _two_configuration_ensemble(S):
+    L = S.Lattice
+    configurations = S.configurations(2)
+    configurations[0] = {'phi': L.zeros(0), 'n': L.zeros(1, dtype=int)}
+    configurations[1] = {'phi': L.zeros(0), 'n': L.zeros(1, dtype=int)}
+    return supervillain.Ensemble(S).from_configurations(configurations)
+
+
+def test_new_topological_observables_are_registered():
+    assert supervillain.observables['TopologicalChargeDensity'] is TopologicalChargeDensity
+    assert supervillain.observables['TopologicalCharge'] is TopologicalCharge
+    assert supervillain.observables['TopologicalChargeSquared'] is TopologicalChargeSquared
+    assert supervillain.observables['TopologicalTwoPoint'] is TopologicalTwoPoint
+    assert supervillain.derivedQuantities['Topological_Topological'] is Topological_Topological
+
+
+def test_topological_charge_squared_autocorrelation_included_for_finite_W():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    for W in (1, 2):
+        S = supervillain.action.Villain(L, kappa=0.5, W=W)
+        ensemble = _two_configuration_ensemble(S)
+        assert TopologicalChargeSquared.autocorrelation(ensemble)
+        assert AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
+
+
+def test_topological_charge_squared_autocorrelation_excluded_for_W_infinite():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=float('inf'))
+    ensemble = _two_configuration_ensemble(S)
+
+    assert not TopologicalChargeSquared.autocorrelation(ensemble)
+    assert not AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
+
+
+def test_total_and_density_excluded_from_autocorrelation():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+    ensemble = _two_configuration_ensemble(S)
+
+    # The total charge is identically zero (no variance), and the density is
+    # field-valued (not a Scalar), so neither enters the autocorrelation-time
+    # computation.
+    assert not TopologicalCharge.autocorrelation(ensemble)
+    assert not TopologicalChargeDensity.autocorrelation(ensemble)

--- a/test/test_topological_charge.py
+++ b/test/test_topological_charge.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+import numpy as np
+import pytest
+
+import supervillain
+from supervillain.batch import Batch
+from supervillain.lattice import d, wedge
+from supervillain.observable.topological import AbsoluteTopologicalChargeDensity
+
+
+def unit_charge_dipole(L):
+    r'''Return an integer 1-form whose charge consists of one +1/-1 pair.'''
+    n = L.zeros(1, dtype=int)
+    origin = L.origin
+
+    n[L.comp_index[1][(0,)]][origin] = 1
+    shifted = list(origin)
+    shifted[0] = 1
+    n[L.comp_index[1][(1,)]][tuple(shifted)] = 1
+
+    return n
+
+
+def test_absolute_topological_charge_density_vacuum_is_zero():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+
+    assert AbsoluteTopologicalChargeDensity.Villain(S, L.zeros(1, dtype=int)) == 0
+
+
+@pytest.mark.parametrize('kappa', [0.05, 0.5, 2.0])
+def test_absolute_topological_charge_density_counts_unit_charge_dipole(kappa):
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=kappa, W=1)
+    n = unit_charge_dipole(L)
+    charge = wedge(d(n), d(n))
+
+    assert np.array_equal(np.sort(np.asarray(charge)[charge != 0]), [-1, 1])
+    assert charge.sum() == 0
+    assert np.abs(charge).sum() == 2
+    assert AbsoluteTopologicalChargeDensity.Villain(S, n) == 2 / L.sites
+
+
+def test_absolute_topological_charge_density_matches_wedge_definition():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    rng = np.random.default_rng(20260629)
+    n = L.zeros(1, dtype=int)
+    n[...] = rng.integers(-2, 3, size=n.shape)
+
+    charge = wedge(d(n), d(n))
+    expected = np.abs(charge).sum() / L.cells_of_degree[4]
+    measured = AbsoluteTopologicalChargeDensity.Villain(S, n)
+
+    # Q is exact on the periodic lattice, while its L1 norm is nonzero.
+    assert charge.sum() == 0
+    assert expected > 0
+    assert measured == expected
+
+
+def test_absolute_topological_charge_density_is_gauge_invariant():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.7, W=1)
+    n = unit_charge_dipole(L)
+    phi = L.zeros(0)
+    k = L.zeros(0, dtype=int)
+    rng = np.random.default_rng(1234)
+    k[...] = rng.integers(-3, 4, size=k.shape)
+
+    transformed = S.gauge_transform({'phi': phi, 'n': n}, k)
+
+    before = AbsoluteTopologicalChargeDensity.Villain(S, n)
+    after = AbsoluteTopologicalChargeDensity.Villain(S, transformed['n'])
+    assert after == before
+
+
+def test_absolute_topological_charge_density_integrates_with_ensemble():
+    L = supervillain.lattice.Lattice(D=4, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=1)
+    configurations = S.configurations(2)
+    configurations[0] = {'phi': L.zeros(0), 'n': L.zeros(1, dtype=int)}
+    configurations[1] = {'phi': L.zeros(0), 'n': unit_charge_dipole(L)}
+    ensemble = supervillain.Ensemble(S).from_configurations(configurations)
+
+    assert (
+        supervillain.observable.AbsoluteTopologicalChargeDensity
+        is AbsoluteTopologicalChargeDensity
+    )
+    assert (
+        supervillain.observables['AbsoluteTopologicalChargeDensity']
+        is AbsoluteTopologicalChargeDensity
+    )
+
+    measured = ensemble.measure(['AbsoluteTopologicalChargeDensity'])
+    values = measured['AbsoluteTopologicalChargeDensity']
+
+    assert isinstance(values, Batch)
+    assert values.shape == (2,)
+    assert np.array_equal(Batch.as_array(values), [0, 2 / L.sites])
+    assert ensemble.AbsoluteTopologicalChargeDensity is values
+    assert 'AbsoluteTopologicalChargeDensity' in ensemble.measured
+    assert AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
+
+
+@pytest.mark.parametrize(('D', 'W'), [(3, 1), (4, 2)])
+def test_absolute_topological_charge_density_rejects_unsupported_models(D, W):
+    L = supervillain.lattice.Lattice(D=D, N=3)
+    S = supervillain.action.Villain(L, kappa=0.5, W=W)
+
+    with pytest.raises(NotImplementedError):
+        AbsoluteTopologicalChargeDensity.Villain(S, L.zeros(1, dtype=int))

--- a/test/test_topological_charge.py
+++ b/test/test_topological_charge.py
@@ -29,7 +29,7 @@ def unit_charge_dipole(L):
 
 
 def charge_density(S, n):
-    r'''The per-configuration charge field Q_x, the ingredient the downstream
+    r'''The per-configuration charge field q_x, the ingredient the downstream
     observables consume.'''
     return TopologicalChargeDensity.Villain(S, n)
 
@@ -48,7 +48,7 @@ def brute_force_correlation(L, f, g):
 
 
 # ---------------------------------------------------------------------------
-# TopologicalChargeDensity: the per-configuration field Q_x, the ingredient
+# TopologicalChargeDensity: the per-configuration field q_x, the ingredient
 # from which the other observables are built.  It is the only observable that
 # depends on n; the rest consume it.
 # ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ def test_topological_charge_density_equals_exact_form_d_of_n_wedge_dn():
     density = TopologicalChargeDensity.Villain(S, n)
     assert density.shape == L.dims
 
-    # Independent path: Q = dn∧dn = d(n∧dn) by the Leibniz rule (since ddn = 0).
+    # Independent path: q = dn∧dn = d(n∧dn) by the Leibniz rule (since ddn = 0).
     # The observable forms dn first and then wedges; here we wedge first (n∧dn)
     # and then take d, a genuinely different sequence of operations.
     exact_form = np.asarray(d(wedge(n, d(n)))).sum(axis=0)
@@ -71,7 +71,7 @@ def test_topological_charge_density_equals_exact_form_d_of_n_wedge_dn():
 
 
 def test_topological_charge_density_is_bilinear():
-    # Q = dn∧dn is quadratic in n, so scaling n by an integer c scales Q by c².
+    # q = dn∧dn is quadratic in n, so scaling n by an integer c scales q by c².
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.7, W=1)
     rng = np.random.default_rng(31415)
@@ -156,7 +156,7 @@ def test_topological_charge_density_squared_integrates_with_ensemble():
 
     assert isinstance(values, Batch)
     assert values.shape == (2,)
-    # vacuum → 0; unit dipole → Q² = 1 on two four-cells → 2/Λ.
+    # vacuum → 0; unit dipole → q² = 1 on two four-cells → 2/Λ.
     assert np.array_equal(Batch.as_array(values), [0, 2 / L.cells_of_degree[4]])
     assert ensemble.TopologicalChargeDensitySquared is values
     assert 'TopologicalChargeDensitySquared' in ensemble.measured
@@ -166,7 +166,7 @@ def test_topological_charge_density_squared_integrates_with_ensemble():
 
 
 # ---------------------------------------------------------------------------
-# TopologicalCharge: the signed total Q_total = ∑_x Q_x, a per-configuration
+# TopologicalCharge: the signed total Q = ∑_x q_x, a per-configuration
 # Observable that sums the density.  Identically zero.
 # ---------------------------------------------------------------------------
 
@@ -179,7 +179,7 @@ def test_topological_charge_sums_the_density_to_zero():
 
     for cfg in (L.zeros(1, dtype=int), unit_charge_dipole(L), n):
         density = charge_density(S, cfg)
-        # Independent total via the exact form Q = d(n∧dn): a sum of an exact
+        # Independent total via the exact form q = d(n∧dn): a sum of an exact
         # form over the closed lattice, so it must vanish identically.
         exact_total = np.asarray(d(wedge(cfg, d(cfg)))).sum()
         assert TopologicalCharge.Villain(S, density) == exact_total
@@ -187,7 +187,7 @@ def test_topological_charge_sums_the_density_to_zero():
 
 
 # ---------------------------------------------------------------------------
-# TopologicalChargeDensitySquared: the same-site value ⟨Q_x²⟩.
+# TopologicalChargeDensitySquared: the same-site value ⟨q_x²⟩.
 # ---------------------------------------------------------------------------
 
 def test_topological_charge_density_squared_vacuum_is_zero():
@@ -202,7 +202,7 @@ def test_topological_charge_density_squared_counts_unit_charge_dipole():
     S = supervillain.action.Villain(L, kappa=0.5, W=1)
     density = charge_density(S, unit_charge_dipole(L))
 
-    # Q is ±1 on two 4-cells, so Q² is 1 on two cells and the mean is 2/Λ.
+    # q is ±1 on two 4-cells, so q² is 1 on two cells and the mean is 2/Λ.
     assert TopologicalChargeDensitySquared.Villain(S, density) == 2 / L.cells_of_degree[4]
 
 
@@ -214,7 +214,7 @@ def test_topological_charge_density_squared_equals_brute_force_origin_correlatio
     n[...] = rng.integers(-2, 3, size=n.shape)
     density = charge_density(S, n)
 
-    # Λ⁻¹∑_x Q_x² is the same-site value of the real-space correlator;
+    # Λ⁻¹∑_x q_x² is the same-site value of the real-space correlator;
     # check it against the independent brute-force correlation at Δx = 0.
     expected = brute_force_correlation(L, density, density)[L.origin]
     assert np.isclose(TopologicalChargeDensitySquared.Villain(S, density), expected)
@@ -222,7 +222,7 @@ def test_topological_charge_density_squared_equals_brute_force_origin_correlatio
 
 
 # ---------------------------------------------------------------------------
-# TopologicalTwoPoint: the Δx-resolved correlator ⟨Q_x Q_{x-Δx}⟩.
+# TopologicalTwoPoint: the Δx-resolved correlator ⟨q_x q_{x-Δx}⟩.
 # ---------------------------------------------------------------------------
 
 def test_topological_two_point_matches_brute_force_real_space():
@@ -259,13 +259,13 @@ def test_topological_two_point_sums_to_zero_because_total_charge_vanishes():
     n = L.zeros(1, dtype=int)
     n[...] = rng.integers(-2, 3, size=n.shape)
 
-    # ∑_Δx ⟨Q_x Q_{x-Δx}⟩ = (1/Λ)(∑_x Q_x)² = 0 since Q_total = 0.
+    # ∑_Δx ⟨q_x q_{x-Δx}⟩ = (1/Λ)(∑_x q_x)² = Q²/Λ = 0 since Q = 0.
     two_point = np.asarray(TopologicalTwoPoint.Villain(S, charge_density(S, n)))
     assert np.isclose(two_point.sum(), 0)
 
 
 # ---------------------------------------------------------------------------
-# Topological_Topological: connected correlator = TwoPoint − ⟨Q⟩⊗⟨Q⟩ correlation.
+# Topological_Topological: connected correlator = TwoPoint − ⟨q⟩⊗⟨q⟩ correlation.
 # ---------------------------------------------------------------------------
 
 def test_topological_topological_subtracts_density_disconnected_piece():
@@ -292,7 +292,7 @@ def test_topological_topological_equals_two_point_when_density_expectation_vanis
     n[...] = rng.integers(-2, 3, size=n.shape)
 
     two_point = np.asarray(TopologicalTwoPoint.Villain(S, charge_density(S, n)))
-    # With ⟨Q⟩ = 0 the disconnected piece vanishes and the connected correlator
+    # With ⟨q⟩ = 0 the disconnected piece vanishes and the connected correlator
     # is exactly the two-point function.
     zero_density = charge_density(S, L.zeros(1, dtype=int))
     result = np.asarray(Topological_Topological.default(S, two_point, zero_density))

--- a/test/test_topological_charge.py
+++ b/test/test_topological_charge.py
@@ -7,7 +7,6 @@ import supervillain
 from supervillain.batch import Batch
 from supervillain.lattice import d, wedge
 from supervillain.observable.topological import (
-    AbsoluteTopologicalChargeDensity,
     TopologicalChargeDensity,
     TopologicalCharge,
     TopologicalChargeSquared,
@@ -109,7 +108,6 @@ def test_topological_charge_density_rejects_non_four_dimensions(D):
 @pytest.mark.parametrize('D', [3, 5])
 @pytest.mark.parametrize('name', [
     'TopologicalChargeDensity',
-    'AbsoluteTopologicalChargeDensity',
     'TopologicalCharge',
     'TopologicalChargeSquared',
     'TopologicalTwoPoint',
@@ -133,63 +131,10 @@ def test_topological_observables_reject_non_four_dimensions_via_ensemble(D, name
 
 
 # ---------------------------------------------------------------------------
-# AbsoluteTopologicalChargeDensity: Λ⁻¹∑|Q(x)|.
+# Ensemble integration: measurement, caching, and registration.
 # ---------------------------------------------------------------------------
 
-def test_absolute_topological_charge_density_vacuum_is_zero():
-    L = supervillain.lattice.Lattice(D=4, N=3)
-    S = supervillain.action.Villain(L, kappa=0.5, W=1)
-
-    assert AbsoluteTopologicalChargeDensity.Villain(S, charge_density(S, L.zeros(1, dtype=int))) == 0
-
-
-@pytest.mark.parametrize('kappa', [0.05, 0.5, 2.0])
-def test_absolute_topological_charge_density_counts_unit_charge_dipole(kappa):
-    L = supervillain.lattice.Lattice(D=4, N=3)
-    S = supervillain.action.Villain(L, kappa=kappa, W=1)
-    n = unit_charge_dipole(L)
-    density = charge_density(S, n)
-
-    assert np.array_equal(np.sort(density[density != 0]), [-1, 1])
-    assert density.sum() == 0
-    assert np.abs(density).sum() == 2
-    assert AbsoluteTopologicalChargeDensity.Villain(S, density) == 2 / L.cells_of_degree[4]
-
-
-def test_absolute_topological_charge_density_matches_wedge_definition():
-    L = supervillain.lattice.Lattice(D=4, N=3)
-    S = supervillain.action.Villain(L, kappa=0.7, W=1)
-    rng = np.random.default_rng(20260629)
-    n = L.zeros(1, dtype=int)
-    n[...] = rng.integers(-2, 3, size=n.shape)
-    density = charge_density(S, n)
-
-    expected = np.abs(density).sum() / L.cells_of_degree[4]
-    measured = AbsoluteTopologicalChargeDensity.Villain(S, density)
-
-    # Q is exact on the periodic lattice, while its L1 norm is nonzero.
-    assert density.sum() == 0
-    assert expected > 0
-    assert measured == expected
-
-
-def test_absolute_topological_charge_density_is_gauge_invariant():
-    L = supervillain.lattice.Lattice(D=4, N=3)
-    S = supervillain.action.Villain(L, kappa=0.7, W=1)
-    n = unit_charge_dipole(L)
-    phi = L.zeros(0)
-    k = L.zeros(0, dtype=int)
-    rng = np.random.default_rng(1234)
-    k[...] = rng.integers(-3, 4, size=k.shape)
-
-    transformed = S.gauge_transform({'phi': phi, 'n': n}, k)
-
-    before = AbsoluteTopologicalChargeDensity.Villain(S, charge_density(S, n))
-    after = AbsoluteTopologicalChargeDensity.Villain(S, charge_density(S, transformed['n']))
-    assert after == before
-
-
-def test_absolute_topological_charge_density_integrates_with_ensemble():
+def test_topological_charge_squared_integrates_with_ensemble():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=1)
     configurations = S.configurations(2)
@@ -198,25 +143,26 @@ def test_absolute_topological_charge_density_integrates_with_ensemble():
     ensemble = supervillain.Ensemble(S).from_configurations(configurations)
 
     assert (
-        supervillain.observable.AbsoluteTopologicalChargeDensity
-        is AbsoluteTopologicalChargeDensity
+        supervillain.observable.TopologicalChargeSquared
+        is TopologicalChargeSquared
     )
     assert (
-        supervillain.observables['AbsoluteTopologicalChargeDensity']
-        is AbsoluteTopologicalChargeDensity
+        supervillain.observables['TopologicalChargeSquared']
+        is TopologicalChargeSquared
     )
 
-    measured = ensemble.measure(['AbsoluteTopologicalChargeDensity'])
-    values = measured['AbsoluteTopologicalChargeDensity']
+    measured = ensemble.measure(['TopologicalChargeSquared'])
+    values = measured['TopologicalChargeSquared']
 
     assert isinstance(values, Batch)
     assert values.shape == (2,)
+    # vacuum → 0; unit dipole → Q² = 1 on two four-cells → 2/Λ.
     assert np.array_equal(Batch.as_array(values), [0, 2 / L.cells_of_degree[4]])
-    assert ensemble.AbsoluteTopologicalChargeDensity is values
-    assert 'AbsoluteTopologicalChargeDensity' in ensemble.measured
+    assert ensemble.TopologicalChargeSquared is values
+    assert 'TopologicalChargeSquared' in ensemble.measured
     # The density ingredient was measured and cached as a side effect.
     assert 'TopologicalChargeDensity' in ensemble.measured
-    assert AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
+    assert TopologicalChargeSquared.autocorrelation(ensemble)
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +187,7 @@ def test_topological_charge_sums_the_density_to_zero():
 
 
 # ---------------------------------------------------------------------------
-# TopologicalChargeSquared: the same-site value χ_0 = ⟨Q_x²⟩.
+# TopologicalChargeSquared: the same-site value ⟨Q_x²⟩.
 # ---------------------------------------------------------------------------
 
 def test_topological_charge_squared_vacuum_is_zero():
@@ -268,7 +214,7 @@ def test_topological_charge_squared_equals_brute_force_origin_correlation():
     n[...] = rng.integers(-2, 3, size=n.shape)
     density = charge_density(S, n)
 
-    # χ_0 = Λ⁻¹∑_x Q_x² is the same-site value of the real-space correlator;
+    # Λ⁻¹∑_x Q_x² is the same-site value of the real-space correlator;
     # check it against the independent brute-force correlation at Δx = 0.
     expected = brute_force_correlation(L, density, density)[L.origin]
     assert np.isclose(TopologicalChargeSquared.Villain(S, density), expected)
@@ -372,7 +318,6 @@ def test_topological_observables_allow_finite_W_greater_than_one(W):
     assert density.sum() == 0
 
     assert TopologicalCharge.Villain(S, density) == 0
-    assert AbsoluteTopologicalChargeDensity.Villain(S, density) == 2 * W ** 2 / L.cells_of_degree[4]
     assert TopologicalChargeSquared.Villain(S, density) == 2 * W ** 4 / L.cells_of_degree[4]
     assert np.asarray(TopologicalTwoPoint.Villain(S, density)).shape == L.dims
 
@@ -388,7 +333,6 @@ def test_topological_observables_W_infinite_measure_zero():
     density = charge_density(S, n)
     assert np.all(density == 0)
     assert TopologicalCharge.Villain(S, density) == 0
-    assert AbsoluteTopologicalChargeDensity.Villain(S, density) == 0
     assert TopologicalChargeSquared.Villain(S, density) == 0
     assert np.all(np.asarray(TopologicalTwoPoint.Villain(S, density)) == 0)
 
@@ -444,7 +388,6 @@ def test_topological_charge_squared_autocorrelation_included_for_finite_W():
         S = supervillain.action.Villain(L, kappa=0.5, W=W)
         ensemble = _two_configuration_ensemble(S)
         assert TopologicalChargeSquared.autocorrelation(ensemble)
-        assert AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
 
 
 def test_topological_charge_squared_autocorrelation_excluded_for_W_infinite():
@@ -453,7 +396,6 @@ def test_topological_charge_squared_autocorrelation_excluded_for_W_infinite():
     ensemble = _two_configuration_ensemble(S)
 
     assert not TopologicalChargeSquared.autocorrelation(ensemble)
-    assert not AbsoluteTopologicalChargeDensity.autocorrelation(ensemble)
 
 
 def test_total_and_density_excluded_from_autocorrelation():

--- a/test/test_topological_charge.py
+++ b/test/test_topological_charge.py
@@ -9,7 +9,7 @@ from supervillain.lattice import d, wedge
 from supervillain.observable.topological import (
     TopologicalChargeDensity,
     TopologicalCharge,
-    TopologicalChargeSquared,
+    TopologicalChargeDensitySquared,
     TopologicalTwoPoint,
     Topological_Topological,
 )
@@ -109,7 +109,7 @@ def test_topological_charge_density_rejects_non_four_dimensions(D):
 @pytest.mark.parametrize('name', [
     'TopologicalChargeDensity',
     'TopologicalCharge',
-    'TopologicalChargeSquared',
+    'TopologicalChargeDensitySquared',
     'TopologicalTwoPoint',
 ])
 def test_topological_observables_reject_non_four_dimensions_via_ensemble(D, name):
@@ -134,7 +134,7 @@ def test_topological_observables_reject_non_four_dimensions_via_ensemble(D, name
 # Ensemble integration: measurement, caching, and registration.
 # ---------------------------------------------------------------------------
 
-def test_topological_charge_squared_integrates_with_ensemble():
+def test_topological_charge_density_squared_integrates_with_ensemble():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=1)
     configurations = S.configurations(2)
@@ -143,26 +143,26 @@ def test_topological_charge_squared_integrates_with_ensemble():
     ensemble = supervillain.Ensemble(S).from_configurations(configurations)
 
     assert (
-        supervillain.observable.TopologicalChargeSquared
-        is TopologicalChargeSquared
+        supervillain.observable.TopologicalChargeDensitySquared
+        is TopologicalChargeDensitySquared
     )
     assert (
-        supervillain.observables['TopologicalChargeSquared']
-        is TopologicalChargeSquared
+        supervillain.observables['TopologicalChargeDensitySquared']
+        is TopologicalChargeDensitySquared
     )
 
-    measured = ensemble.measure(['TopologicalChargeSquared'])
-    values = measured['TopologicalChargeSquared']
+    measured = ensemble.measure(['TopologicalChargeDensitySquared'])
+    values = measured['TopologicalChargeDensitySquared']
 
     assert isinstance(values, Batch)
     assert values.shape == (2,)
     # vacuum → 0; unit dipole → Q² = 1 on two four-cells → 2/Λ.
     assert np.array_equal(Batch.as_array(values), [0, 2 / L.cells_of_degree[4]])
-    assert ensemble.TopologicalChargeSquared is values
-    assert 'TopologicalChargeSquared' in ensemble.measured
+    assert ensemble.TopologicalChargeDensitySquared is values
+    assert 'TopologicalChargeDensitySquared' in ensemble.measured
     # The density ingredient was measured and cached as a side effect.
     assert 'TopologicalChargeDensity' in ensemble.measured
-    assert TopologicalChargeSquared.autocorrelation(ensemble)
+    assert TopologicalChargeDensitySquared.autocorrelation(ensemble)
 
 
 # ---------------------------------------------------------------------------
@@ -187,26 +187,26 @@ def test_topological_charge_sums_the_density_to_zero():
 
 
 # ---------------------------------------------------------------------------
-# TopologicalChargeSquared: the same-site value ⟨Q_x²⟩.
+# TopologicalChargeDensitySquared: the same-site value ⟨Q_x²⟩.
 # ---------------------------------------------------------------------------
 
-def test_topological_charge_squared_vacuum_is_zero():
+def test_topological_charge_density_squared_vacuum_is_zero():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=1)
 
-    assert TopologicalChargeSquared.Villain(S, charge_density(S, L.zeros(1, dtype=int))) == 0
+    assert TopologicalChargeDensitySquared.Villain(S, charge_density(S, L.zeros(1, dtype=int))) == 0
 
 
-def test_topological_charge_squared_counts_unit_charge_dipole():
+def test_topological_charge_density_squared_counts_unit_charge_dipole():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=1)
     density = charge_density(S, unit_charge_dipole(L))
 
     # Q is ±1 on two 4-cells, so Q² is 1 on two cells and the mean is 2/Λ.
-    assert TopologicalChargeSquared.Villain(S, density) == 2 / L.cells_of_degree[4]
+    assert TopologicalChargeDensitySquared.Villain(S, density) == 2 / L.cells_of_degree[4]
 
 
-def test_topological_charge_squared_equals_brute_force_origin_correlation():
+def test_topological_charge_density_squared_equals_brute_force_origin_correlation():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.7, W=1)
     rng = np.random.default_rng(11)
@@ -217,7 +217,7 @@ def test_topological_charge_squared_equals_brute_force_origin_correlation():
     # Λ⁻¹∑_x Q_x² is the same-site value of the real-space correlator;
     # check it against the independent brute-force correlation at Δx = 0.
     expected = brute_force_correlation(L, density, density)[L.origin]
-    assert np.isclose(TopologicalChargeSquared.Villain(S, density), expected)
+    assert np.isclose(TopologicalChargeDensitySquared.Villain(S, density), expected)
     assert expected > 0
 
 
@@ -240,7 +240,7 @@ def test_topological_two_point_matches_brute_force_real_space():
     assert np.allclose(two_point, brute_force_correlation(L, density, density))
 
 
-def test_topological_two_point_origin_equals_charge_squared():
+def test_topological_two_point_origin_equals_charge_density_squared():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.7, W=1)
     rng = np.random.default_rng(8)
@@ -249,7 +249,7 @@ def test_topological_two_point_origin_equals_charge_squared():
     density = charge_density(S, n)
 
     two_point = np.asarray(TopologicalTwoPoint.Villain(S, density))
-    assert np.isclose(two_point[L.origin], TopologicalChargeSquared.Villain(S, density))
+    assert np.isclose(two_point[L.origin], TopologicalChargeDensitySquared.Villain(S, density))
 
 
 def test_topological_two_point_sums_to_zero_because_total_charge_vanishes():
@@ -318,7 +318,7 @@ def test_topological_observables_allow_finite_W_greater_than_one(W):
     assert density.sum() == 0
 
     assert TopologicalCharge.Villain(S, density) == 0
-    assert TopologicalChargeSquared.Villain(S, density) == 2 * W ** 4 / L.cells_of_degree[4]
+    assert TopologicalChargeDensitySquared.Villain(S, density) == 2 * W ** 4 / L.cells_of_degree[4]
     assert np.asarray(TopologicalTwoPoint.Villain(S, density)).shape == L.dims
 
 
@@ -333,7 +333,7 @@ def test_topological_observables_W_infinite_measure_zero():
     density = charge_density(S, n)
     assert np.all(density == 0)
     assert TopologicalCharge.Villain(S, density) == 0
-    assert TopologicalChargeSquared.Villain(S, density) == 0
+    assert TopologicalChargeDensitySquared.Villain(S, density) == 0
     assert np.all(np.asarray(TopologicalTwoPoint.Villain(S, density)) == 0)
 
 
@@ -355,7 +355,7 @@ def test_new_topological_observables_are_gauge_invariant():
     density_transformed = charge_density(S, transformed['n'])
 
     assert np.array_equal(density_transformed, density)
-    assert TopologicalChargeSquared.Villain(S, density_transformed) == TopologicalChargeSquared.Villain(S, density)
+    assert TopologicalChargeDensitySquared.Villain(S, density_transformed) == TopologicalChargeDensitySquared.Villain(S, density)
     assert np.allclose(
         np.asarray(TopologicalTwoPoint.Villain(S, density_transformed)),
         np.asarray(TopologicalTwoPoint.Villain(S, density)),
@@ -377,25 +377,25 @@ def _two_configuration_ensemble(S):
 def test_new_topological_observables_are_registered():
     assert supervillain.observables['TopologicalChargeDensity'] is TopologicalChargeDensity
     assert supervillain.observables['TopologicalCharge'] is TopologicalCharge
-    assert supervillain.observables['TopologicalChargeSquared'] is TopologicalChargeSquared
+    assert supervillain.observables['TopologicalChargeDensitySquared'] is TopologicalChargeDensitySquared
     assert supervillain.observables['TopologicalTwoPoint'] is TopologicalTwoPoint
     assert supervillain.derivedQuantities['Topological_Topological'] is Topological_Topological
 
 
-def test_topological_charge_squared_autocorrelation_included_for_finite_W():
+def test_topological_charge_density_squared_autocorrelation_included_for_finite_W():
     L = supervillain.lattice.Lattice(D=4, N=3)
     for W in (1, 2):
         S = supervillain.action.Villain(L, kappa=0.5, W=W)
         ensemble = _two_configuration_ensemble(S)
-        assert TopologicalChargeSquared.autocorrelation(ensemble)
+        assert TopologicalChargeDensitySquared.autocorrelation(ensemble)
 
 
-def test_topological_charge_squared_autocorrelation_excluded_for_W_infinite():
+def test_topological_charge_density_squared_autocorrelation_excluded_for_W_infinite():
     L = supervillain.lattice.Lattice(D=4, N=3)
     S = supervillain.action.Villain(L, kappa=0.5, W=float('inf'))
     ensemble = _two_configuration_ensemble(S)
 
-    assert not TopologicalChargeSquared.autocorrelation(ensemble)
+    assert not TopologicalChargeDensitySquared.autocorrelation(ensemble)
 
 
 def test_total_and_density_excluded_from_autocorrelation():


### PR DESCRIPTION
Summary:
- add the four-dimensional W=1 AbsoluteTopologicalChargeDensity observable
- expose it through the public observable registry
- document the definition and include a configuration-generation usage example
- test the vacuum, a charge dipole, the wedge definition, gauge invariance, ensemble integration, and unsupported models
- correct the ClassicWorm Sphinx reference needed by the strict documentation build

Testing:
- env PYTHONPATH=. uv run pytest -q test/test_topological_charge.py (9 passed)
- env PYTHONPATH=. uv run --with sphinx-toolbox sphinx-build -b html . _build/html -W --keep-going -E -a (passed)

Numerical experiment scripts, generated configurations, analysis data, and plots are intentionally excluded.