### PR TITLE
Docs: right-align equation numbers via math.css

### DIFF
--- a/_static/css/math.css
+++ b/_static/css/math.css
@@ -1,0 +1,8 @@
+.eqno {
+    float: right;
+}
+
+span.eqno a.headerlink {
+    position: relative;
+    z-index: 1;
+}

--- a/conf.py
+++ b/conf.py
@@ -85,6 +85,12 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'css/math.css',
+]
+
 favicons = [
         'favicon/favicon.ico',
         'favicon/favicon-16x16.png',


### PR DESCRIPTION
Adds a small documentation stylesheet, cherry-picked from `feature/chiral-3450`.

## Changes
- `_static/css/math.css` — floats equation numbers to the right and keeps the `.eqno` headerlink above the equation (clickable).
- `conf.py` — registers the stylesheet via `html_css_files`.

## Notes
`make html` builds cleanly and the stylesheet is linked from `index.html` and copied to `_build/html/_static/css/math.css`.

The `$\Delta{}n_\mu$` math-compilation fix from that branch was **not** included here — it is already on `main` (`supervillain/generator/villain/cohomology.py:25`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)